### PR TITLE
feat: Implement request timeout

### DIFF
--- a/examples/starwars/main.go
+++ b/examples/starwars/main.go
@@ -22,7 +22,7 @@ func append(tx s2.Sender[*s2.AppendInput], tail uint64) error {
 	if err != nil {
 		return err
 	}
-	defer rtx.CloseSend()
+	defer rtx.Close()
 
 	scanner := bufio.NewScanner(conn)
 	for scanner.Scan() {

--- a/s2-bentobox/output.go
+++ b/s2-bentobox/output.go
@@ -98,7 +98,7 @@ func appendWorker(
 	defer close(appendWorkerCloser)
 	defer close(replyQ)
 	defer func(sender s2.Sender[*s2.AppendInput]) {
-		_ = sender.CloseSend()
+		_ = sender.Close()
 	}(sender)
 
 	attemptsLeft := 3

--- a/s2/account_service_requests.go
+++ b/s2/account_service_requests.go
@@ -19,6 +19,10 @@ func (r *listBasinsServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelNoSideEffects
 }
 
+func (r *listBasinsServiceRequest) IsStreaming() bool {
+	return false
+}
+
 func (r *listBasinsServiceRequest) Send(ctx context.Context) (*ListBasinsResponse, error) {
 	req := &pb.ListBasinsRequest{
 		Prefix:     r.Req.Prefix,
@@ -57,6 +61,10 @@ type createBasinServiceRequest struct {
 
 func (r *createBasinServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelIdempotent
+}
+
+func (r *createBasinServiceRequest) IsStreaming() bool {
+	return false
 }
 
 func (r *createBasinServiceRequest) Send(ctx context.Context) (*BasinInfo, error) {
@@ -100,6 +108,10 @@ func (r *deleteBasinServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelIdempotent
 }
 
+func (r *deleteBasinServiceRequest) IsStreaming() bool {
+	return false
+}
+
 func (r *deleteBasinServiceRequest) Send(ctx context.Context) (struct{}, error) {
 	req := &pb.DeleteBasinRequest{
 		Basin: r.Req.Basin,
@@ -125,6 +137,10 @@ type reconfigureBasinServiceRequest struct {
 
 func (r *reconfigureBasinServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelIdempotent
+}
+
+func (r *reconfigureBasinServiceRequest) IsStreaming() bool {
+	return false
 }
 
 func (r *reconfigureBasinServiceRequest) Send(ctx context.Context) (*BasinConfig, error) {
@@ -165,6 +181,10 @@ type getBasinConfigRequest struct {
 
 func (r *getBasinConfigRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelNoSideEffects
+}
+
+func (r *getBasinConfigRequest) IsStreaming() bool {
+	return false
 }
 
 func (r *getBasinConfigRequest) Send(ctx context.Context) (*BasinConfig, error) {

--- a/s2/basin_service_requests.go
+++ b/s2/basin_service_requests.go
@@ -19,6 +19,10 @@ func (r *listStreamsServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelNoSideEffects
 }
 
+func (r *listStreamsServiceRequest) IsStreaming() bool {
+	return false
+}
+
 func (r *listStreamsServiceRequest) Send(ctx context.Context) (*ListStreamsResponse, error) {
 	req := &pb.ListStreamsRequest{
 		Prefix:     r.Req.Prefix,
@@ -54,6 +58,10 @@ func (r *createStreamServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelIdempotent
 }
 
+func (r *createStreamServiceRequest) IsStreaming() bool {
+	return false
+}
+
 func (r *createStreamServiceRequest) Send(ctx context.Context) (*StreamInfo, error) {
 	config, err := streamConfigIntoProto(r.Req.Config)
 	if err != nil {
@@ -86,6 +94,10 @@ func (r *deleteStreamServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelIdempotent
 }
 
+func (r *deleteStreamServiceRequest) IsStreaming() bool {
+	return false
+}
+
 func (r *deleteStreamServiceRequest) Send(ctx context.Context) (struct{}, error) {
 	req := &pb.DeleteStreamRequest{
 		Stream: r.Req.Stream,
@@ -111,6 +123,10 @@ type reconfigureStreamServiceRequest struct {
 
 func (r *reconfigureStreamServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelIdempotent
+}
+
+func (r *reconfigureStreamServiceRequest) IsStreaming() bool {
+	return false
 }
 
 func (r *reconfigureStreamServiceRequest) Send(ctx context.Context) (*StreamConfig, error) {
@@ -151,6 +167,10 @@ type getStreamConfigServiceRequest struct {
 
 func (r *getStreamConfigServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelNoSideEffects
+}
+
+func (r *getStreamConfigServiceRequest) IsStreaming() bool {
+	return false
 }
 
 func (r *getStreamConfigServiceRequest) Send(ctx context.Context) (*StreamConfig, error) {

--- a/s2/batching.go
+++ b/s2/batching.go
@@ -194,7 +194,7 @@ func appendRecordBatchingWorker(
 	var lingerCh <-chan time.Time
 
 	// Close the input sender on exit.
-	defer sender.CloseSend() //nolint:errcheck
+	defer sender.Close()
 
 	for {
 		if recordsToFlush.IsEmpty() {
@@ -261,7 +261,7 @@ func (s *AppendRecordBatchingSender) Send(record AppendRecord) error {
 }
 
 // Close the sender gracefully.
-func (s *AppendRecordBatchingSender) CloseSend() error {
+func (s *AppendRecordBatchingSender) Close() error {
 	s.closeWorkerCancel()
 	<-s.workerExitCtx.Done()
 

--- a/s2/batching_test.go
+++ b/s2/batching_test.go
@@ -51,7 +51,7 @@ func (s *testAppendSessionSender) Send(input *AppendInput) error {
 	return nil
 }
 
-func (s *testAppendSessionSender) CloseSend() error {
+func (s *testAppendSessionSender) Close() error {
 	s.closed.Store(true)
 
 	return nil
@@ -101,7 +101,7 @@ func TestAppendRecordBatchingMechanics(t *testing.T) {
 					require.NoError(t, recordSender.Send(AppendRecord{Body: []byte(body)}))
 				}
 
-				require.NoError(t, recordSender.CloseSend())
+				require.NoError(t, recordSender.Close())
 
 				i := 0
 
@@ -180,7 +180,7 @@ func TestAppendRecordBatchingLinger(t *testing.T) {
 	sendNext("large string")
 	sendNext("")
 
-	require.NoError(t, recordSender.CloseSend())
+	require.NoError(t, recordSender.Close())
 
 	expectedBatches := [][]string{
 		{"r_0", "r_1"},
@@ -218,7 +218,7 @@ func TestAppendRecordBatchingErrorSizeLimits(t *testing.T) {
 	require.NoError(t, err)
 
 	require.ErrorIs(t, recordSender.Send(record), ErrRecordTooBig)
-	require.ErrorIs(t, recordSender.CloseSend(), ErrRecordTooBig)
+	require.ErrorIs(t, recordSender.Close(), ErrRecordTooBig)
 }
 
 func TestAppendRecordBatchingAppendInputOpts(t *testing.T) {
@@ -251,7 +251,7 @@ func TestAppendRecordBatchingAppendInputOpts(t *testing.T) {
 		require.NoError(t, recordSender.Send(record))
 	}
 
-	require.NoError(t, recordSender.CloseSend())
+	require.NoError(t, recordSender.Close())
 
 	batches := batchSender.Inputs(t)
 

--- a/s2/example_test.go
+++ b/s2/example_test.go
@@ -387,7 +387,7 @@ func ExampleStreamClient_AppendSession() {
 	if err != nil {
 		panic(err)
 	}
-	defer recordSender.CloseSend() //nolint:errcheck
+	defer recordSender.Close()
 
 	send := make(chan error)
 
@@ -471,7 +471,7 @@ func ExampleAppendRecordBatchingSender() {
 	if err != nil {
 		panic(err)
 	}
-	defer recordSender.CloseSend() //nolint:errcheck
+	defer recordSender.Close()
 
 	records := []s2.AppendRecord{
 		{Body: []byte("my record 1")},

--- a/s2/stream_service_requests.go
+++ b/s2/stream_service_requests.go
@@ -17,6 +17,10 @@ func (r *checkTailServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelNoSideEffects
 }
 
+func (r *checkTailServiceRequest) IsStreaming() bool {
+	return false
+}
+
 func (r *checkTailServiceRequest) Send(ctx context.Context) (uint64, error) {
 	req := &pb.CheckTailRequest{
 		Stream: r.Stream,
@@ -39,6 +43,10 @@ type appendServiceRequest struct {
 
 func (r *appendServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelUnknown
+}
+
+func (r *appendServiceRequest) IsStreaming() bool {
+	return false
 }
 
 func (r *appendServiceRequest) Send(ctx context.Context) (*AppendOutput, error) {
@@ -73,6 +81,10 @@ type appendSessionServiceRequest struct {
 
 func (r *appendSessionServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelUnknown
+}
+
+func (r *appendSessionServiceRequest) IsStreaming() bool {
+	return true
 }
 
 func (r *appendSessionServiceRequest) Send(ctx context.Context) (*channel[*AppendInput, *AppendOutput], error) {
@@ -119,6 +131,10 @@ func (r *readServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelNoSideEffects
 }
 
+func (r *readServiceRequest) IsStreaming() bool {
+	return false
+}
+
 func (r *readServiceRequest) Send(ctx context.Context) (ReadOutput, error) {
 	limit := &pb.ReadLimit{
 		Count: r.Req.Limit.Count,
@@ -153,6 +169,10 @@ type readSessionServiceRequest struct {
 
 func (r *readSessionServiceRequest) IdempotencyLevel() idempotencyLevel {
 	return idempotencyLevelNoSideEffects
+}
+
+func (r *readSessionServiceRequest) IsStreaming() bool {
+	return true
 }
 
 func (r *readSessionServiceRequest) Send(ctx context.Context) (Receiver[ReadOutput], error) {

--- a/s2/types.go
+++ b/s2/types.go
@@ -256,11 +256,13 @@ type Sender[T any] interface {
 	// Block until the item has been sent.
 	Send(T) error
 	// Close the sender.
-	CloseSend() error
+	Close() error
 }
 
 type recvInner[F, T any] struct {
-	Client    Receiver[*F]
+	Client interface {
+		Recv() (*F, error)
+	}
 	ConvertFn func(*F) (T, error)
 }
 
@@ -276,7 +278,10 @@ func (r recvInner[F, T]) Recv() (T, error) {
 }
 
 type sendInner[F, T any] struct {
-	Client    Sender[*T]
+	Client interface {
+		Send(*T) error
+		CloseSend() error
+	}
 	ConvertFn func(F) (*T, error)
 }
 
@@ -289,7 +294,7 @@ func (r sendInner[F, T]) Send(f F) error {
 	return r.Client.Send(t)
 }
 
-func (r sendInner[F, T]) CloseSend() error {
+func (r sendInner[F, T]) Close() error {
 	return r.Client.CloseSend()
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Implement request timeout feature in S2 SDK with support for differentiating streaming requests and standardizing sender interface.
> 
>   - **Timeout Implementation**:
>     - Add `RequestTimeout` to `clientConfig` in `client.go` with a default of 5 seconds.
>     - Modify `sendRetryable` and `sendRetryableInner` in `client.go` to use `RequestTimeout` for non-streaming requests.
>     - Introduce `sendAttempt` function in `client.go` to handle request timeout logic.
>   - **Streaming Handling**:
>     - Add `IsStreaming` method to service request structs in `account_service_requests.go`, `basin_service_requests.go`, and `stream_service_requests.go` to differentiate streaming from non-streaming requests.
>   - **Method Renaming**:
>     - Rename `CloseSend` to `Close` in `types.go`, `batching.go`, `batching_test.go`, and `example_test.go` to standardize sender interface.
>   - **Testing**:
>     - Update `TestSendRetryable` in `client_test.go` to include cases for `context.DeadlineExceeded` errors.
>   - **Miscellaneous**:
>     - Minor changes in `output.go` and `example_test.go` to align with new method names and timeout logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-sdk-go&utm_source=github&utm_medium=referral)<sup> for 432b8e0d684b962eb8b71f6fa9853e87f6fb09a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->