### PR TITLE
fix: Batcher Close() cancels context before final flush

### DIFF
--- a/s2/batcher.go
+++ b/s2/batcher.go
@@ -178,8 +178,6 @@ func (b *Batcher) Flush() {
 
 // Flushes any remaining records and closes the batcher.
 func (b *Batcher) Close() {
-	b.cancel() // Cancel first to unblock any flushLocked waiting on channel send
-
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
@@ -193,5 +191,6 @@ func (b *Batcher) Close() {
 	}
 	b.mu.Unlock()
 
+	b.cancel()
 	close(b.batchesCh)
 }


### PR DESCRIPTION
closes #142 