### PR TITLE
fix: validate fencing token length

### DIFF
--- a/s2/error.go
+++ b/s2/error.go
@@ -33,6 +33,14 @@ type ErrorInfo struct {
 	Message string `json:"message"`
 }
 
+func newValidationError(message string) *S2Error {
+	return &S2Error{
+		Message: message,
+		Code:    "VALIDATION",
+		Origin:  "sdk",
+	}
+}
+
 func (e *S2Error) Error() string {
 	if e.Code != "" {
 		return fmt.Sprintf("S2 API error %s: %s (HTTP %d)", e.Code, e.Message, e.Status)

--- a/s2/stream_integration_test.go
+++ b/s2/stream_integration_test.go
@@ -2063,8 +2063,8 @@ func TestAppend_FencingTokenTooLong(t *testing.T) {
 	})
 
 	var s2Err *s2.S2Error
-	if !errors.As(err, &s2Err) || s2Err.Status != 422 {
-		t.Errorf("Expected 422 error for fencing token too long, got: %v", err)
+	if !errors.As(err, &s2Err) || s2Err.Origin != "sdk" {
+		t.Fatalf("Expected SDK validation error for fencing token too long, got: %v", err)
 	}
 	t.Logf("Got expected error: %v", err)
 }


### PR DESCRIPTION
## Summary
- Reject fencing tokens exceeding 36 bytes in `prepareAppendInput`, matching Rust SDK (`FencingToken::from_str`, types.rs:2672) and TS SDK (`AppendInput.create`, types.ts:229)
- Adds `MaxFencingTokenLength` constant

## Test plan
- [ ] Verify existing tests pass
- [ ] Verify append with fencing token > 36 bytes returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)