### PR TITLE
fix: include tail position in RangeNotSatisfiableError

### DIFF
--- a/s2/error_test.go
+++ b/s2/error_test.go
@@ -36,7 +36,29 @@ func TestDecodeAPIError_FallbackStatusText(t *testing.T) {
 	}
 }
 
-func TestDecodeAPIError_RangeNotSatisfiable(t *testing.T) {
+func TestDecodeAPIError_RangeNotSatisfiable_WithTail(t *testing.T) {
+	body := []byte(`{"tail":{"seq_num":42,"timestamp":1234}}`)
+	err := decodeAPIError(http.StatusRequestedRangeNotSatisfiable, body)
+
+	var rangeErr *RangeNotSatisfiableError
+	if !errors.As(err, &rangeErr) {
+		t.Fatalf("expected RangeNotSatisfiableError, got %T", err)
+	}
+	if rangeErr.Status != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("expected status 416, got %d", rangeErr.Status)
+	}
+	if rangeErr.Tail == nil {
+		t.Fatal("expected Tail to be set")
+	}
+	if rangeErr.Tail.SeqNum != 42 {
+		t.Fatalf("expected tail seq_num 42, got %d", rangeErr.Tail.SeqNum)
+	}
+	if rangeErr.Tail.Timestamp != 1234 {
+		t.Fatalf("expected tail timestamp 1234, got %d", rangeErr.Tail.Timestamp)
+	}
+}
+
+func TestDecodeAPIError_RangeNotSatisfiable_PlainBody(t *testing.T) {
 	err := decodeAPIError(http.StatusRequestedRangeNotSatisfiable, []byte("custom range error"))
 
 	var rangeErr *RangeNotSatisfiableError
@@ -49,7 +71,19 @@ func TestDecodeAPIError_RangeNotSatisfiable(t *testing.T) {
 	if rangeErr.Message != "custom range error" {
 		t.Fatalf("expected message %q, got %q", "custom range error", rangeErr.Message)
 	}
-	if rangeErr.Code != "RANGE_NOT_SATISFIABLE" {
-		t.Fatalf("expected code RANGE_NOT_SATISFIABLE, got %q", rangeErr.Code)
+	if rangeErr.Tail != nil {
+		t.Fatal("expected Tail to be nil for plain body")
+	}
+}
+
+func TestDecodeAPIError_RangeNotSatisfiable_EmptyBody(t *testing.T) {
+	err := decodeAPIError(http.StatusRequestedRangeNotSatisfiable, nil)
+
+	var rangeErr *RangeNotSatisfiableError
+	if !errors.As(err, &rangeErr) {
+		t.Fatalf("expected RangeNotSatisfiableError, got %T", err)
+	}
+	if rangeErr.Tail != nil {
+		t.Fatal("expected Tail to be nil for empty body")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `Tail *StreamPosition` field to `RangeNotSatisfiableError`, matching Rust SDK (`S2Error::ReadUnwritten(StreamPosition)`, types.rs:3426) and TS SDK (`RangeNotSatisfiableError.tail`, error.ts:366)
- Parse 416 response body as JSON `TailResponse` to extract the tail position
- Falls back to plain string message if body is not valid JSON

## Test plan
- [x] `TestDecodeAPIError_RangeNotSatisfiable_WithTail` — JSON body with tail parsed correctly
- [x] `TestDecodeAPIError_RangeNotSatisfiable_PlainBody` — non-JSON body used as message, tail is nil
- [x] `TestDecodeAPIError_RangeNotSatisfiable_EmptyBody` — empty body, tail is nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)