### PR TITLE
fix: enforce 1 MiB minimum for MaxInflightBytes

### DIFF
--- a/s2/append_session.go
+++ b/s2/append_session.go
@@ -56,7 +56,10 @@ func (s *StreamClient) AppendSession(ctx context.Context, opts *AppendSessionOpt
 		ctx = context.Background()
 	}
 
-	opts = applyAppendSessionDefaults(opts, s.basinClient.retryConfig)
+	opts, err := applyAppendSessionDefaults(opts, s.basinClient.retryConfig)
+	if err != nil {
+		return nil, err
+	}
 	pumpCtx, pumpCancel := context.WithCancel(ctx)
 
 	session := &AppendSession{


### PR DESCRIPTION
## Summary
- Return validation error if `MaxInflightBytes < 1 MiB` instead of allowing any value
- Matches Rust SDK behavior (returns `ValidationError`, session/append.rs:118-119)
- Aligns with team decision to standardize on returning errors for config validation

## Test plan
- [x] Existing tests pass
- [ ] Add test for rejected config < 1 MiB (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)