### PR TITLE
fix: enforce producer backpressure at append acceptance

### DIFF
--- a/s2/producer.go
+++ b/s2/producer.go
@@ -78,15 +78,15 @@ func (p *Producer) processBatch(batch *BatchOutput) {
 		return
 	}
 
+	ticket, err := future.Wait(p.ctx)
+	if err != nil {
+		p.resolveBatchError(batch.recordMeta, err)
+		return
+	}
+
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
-
-		ticket, err := future.Wait(p.ctx)
-		if err != nil {
-			p.resolveBatchError(batch.recordMeta, err)
-			return
-		}
 
 		ack, err := ticket.Ack(p.ctx)
 		if err != nil {


### PR DESCRIPTION
## Summary
- wait for append-session acceptance inline in `Producer.processBatch` before moving to the next batch
- keep ack waiting asynchronous so durability notifications remain non-blocking
- add a regression test that ensures no second batch is submitted before first acceptance is released

## Test plan
- [x] `go test -v $(rg --files s2 -g '*.go' -g '!s2/*_test.go') s2/test_helpers_test.go s2/producer_test.go -run 'TestProducer_SubmitWaitsForAcceptanceBeforeNextBatch|TestProducer_SubmitSerializesAppendSessionCalls|TestProducer_CloseDrains' -count=1`

Made with [Cursor](https://cursor.com)