### PR TITLE
fix: avoid append session startup deadlock in transport handshake

### DIFF
--- a/s2/append.go
+++ b/s2/append.go
@@ -156,14 +156,14 @@ func (p *transportAppendSession) connectAndRead(req *http.Request, pipeWriter *i
 		return
 	}
 
+	p.mu.Lock()
 	select {
 	case <-p.closed:
+		p.mu.Unlock()
 		resp.Body.Close()
 		return
 	default:
 	}
-
-	p.mu.Lock()
 	p.conn = resp
 	p.mu.Unlock()
 
@@ -233,6 +233,7 @@ func (p *transportAppendSession) Close() error {
 }
 
 func (p *transportAppendSession) readAcksLoop(conn *http.Response) {
+	defer conn.Body.Close()
 	defer p.Close()
 	defer close(p.acksCh)
 	defer close(p.errorsCh)


### PR DESCRIPTION
## Summary
- decouple append transport startup from synchronous `http.Client.Do` so session startup no longer blocks the pump goroutine
- expose request writer immediately and perform connect/response handling asynchronously, reporting connect/status failures through existing session error paths
- harden transport session concurrency by guarding shared connection/writer state during connect, append, and close races

## Test plan
- [x] `go test -v $(rg --files s2 -g '*.go' -g '!s2/*_test.go') s2/test_helpers_test.go s2/append_session_retry_test.go -run 'TestAppendSession_RetryAfterSendError|TestAppendSession_CloseDuringRetry|TestAppendSession_MaxAttemptsExhausted' -count=1`

Made with [Cursor](https://cursor.com)