### PR TITLE
fix: set default max inflight to 5 MiB

### DIFF
--- a/s2/append_utils.go
+++ b/s2/append_utils.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	defaultMaxInflightBytes = 10 * 1024 * 1024 // 10 MiB
-	minInflightBytes        = 1 * 1024 * 1024  // 1 MiB
+	defaultMaxInflightBytes = 5 * 1024 * 1024 // 5 MiB
+	minInflightBytes        = 1 * 1024 * 1024 // 1 MiB
 )
 
 // Represents a pending batch submission to an [AppendSession].

--- a/s2/types.go
+++ b/s2/types.go
@@ -458,7 +458,7 @@ type BatchingOptions struct {
 }
 
 type AppendSessionOptions struct {
-	// Aggregate size of records, to allow in-flight before applying backpressure (default: 10 MiB).
+	// Aggregate size of records, to allow in-flight before applying backpressure (default: 5 MiB).
 	MaxInflightBytes uint64
 	// Maximum number of batches allowed in-flight before applying backpressure.
 	MaxInflightBatches uint32


### PR DESCRIPTION
## Summary
- set default max inflight to 5 MiB
- update AppendSessionOptions doc comment

## Testing
- not run (not requested)