### PR TITLE
fix: prevent append session submit-close race

### DIFF
--- a/s2/append_session.go
+++ b/s2/append_session.go
@@ -33,8 +33,8 @@ type AppendSession struct {
 
 	readWG sync.WaitGroup
 
-	closing      atomic.Bool
-	closeDone    chan struct{}
+	closing       atomic.Bool
+	closeDone     chan struct{}
 	closeDoneOnce sync.Once
 
 	closed    bool
@@ -106,7 +106,12 @@ func (r *AppendSession) createSubmitFuture(input *AppendInput, size int64) *Subm
 			return
 		}
 
-		entry := r.enqueueEntry(input, size)
+		entry, err := r.enqueueReservedEntry(input, size)
+		if err != nil {
+			r.capacity.release(size)
+			errCh <- err
+			return
+		}
 		ticketCh <- &BatchSubmitTicket{ackCh: entry.resultCh}
 	}()
 
@@ -173,8 +178,10 @@ func (r *AppendSession) LastAckedPosition() *AppendAck {
 	return r.lastAckedPosition
 }
 
-// adds the entry to the inflight queue
-func (r *AppendSession) enqueueEntry(input *AppendInput, size int64) *inflightEntry {
+// Adds a capacity-reserved entry to the inflight queue unless shutdown has already started.
+// Serializing this with inflightMu prevents late enqueues from racing with the pump's empty-queue
+// shutdown check and final Close cleanup.
+func (r *AppendSession) enqueueReservedEntry(input *AppendInput, size int64) (*inflightEntry, error) {
 	entry := &inflightEntry{
 		input:          input,
 		expectedCount:  len(input.Records),
@@ -184,12 +191,16 @@ func (r *AppendSession) enqueueEntry(input *AppendInput, size int64) *inflightEn
 	}
 
 	r.inflightMu.Lock()
+	if r.closing.Load() {
+		r.inflightMu.Unlock()
+		return nil, ErrSessionClosed
+	}
 	r.inflightQueue = append(r.inflightQueue, entry)
 	r.inflightMu.Unlock()
 
 	r.wakeupPump()
 
-	return entry
+	return entry, nil
 }
 
 // the main session loop that processes the inflight queue

--- a/s2/append_session_retry_test.go
+++ b/s2/append_session_retry_test.go
@@ -360,6 +360,93 @@ func TestAppendSession_CloseRejectsNewSubmits(t *testing.T) {
 	}
 }
 
+func TestAppendSession_CloseRejectsLateReservedEnqueue(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	retryCfg := &RetryConfig{
+		MaxAttempts:       2,
+		MinBaseDelay:      time.Millisecond,
+		MaxBaseDelay:      time.Millisecond,
+		AppendRetryPolicy: AppendRetryPolicyAll,
+	}
+
+	stream := newTestStreamClientForAppend(retryCfg)
+	stream.appendSessionFactory = func(context.Context) (*transportAppendSession, error) {
+		return newTransportSession(stream, &signalWriteCloser{}), nil
+	}
+
+	session, err := stream.AppendSession(ctx, &AppendSessionOptions{RetryConfig: retryCfg})
+	if err != nil {
+		t.Fatalf("append session failed: %v", err)
+	}
+
+	prepared, size, err := prepareAppendInput(&AppendInput{
+		Records: []AppendRecord{{Body: []byte("x")}},
+	})
+	if err != nil {
+		t.Fatalf("prepare append input failed: %v", err)
+	}
+
+	if err := session.capacity.reserve(ctx, size); err != nil {
+		t.Fatalf("reserve failed: %v", err)
+	}
+	defer session.capacity.release(size)
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	entry, err := session.enqueueReservedEntry(prepared, size)
+	if !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("expected ErrSessionClosed, got %v", err)
+	}
+	if entry != nil {
+		t.Fatal("expected no entry to be returned after close")
+	}
+
+	session.inflightMu.RLock()
+	queueLen := len(session.inflightQueue)
+	session.inflightMu.RUnlock()
+	if queueLen != 0 {
+		t.Fatalf("expected empty inflight queue after rejected enqueue, got %d entries", queueLen)
+	}
+}
+
+func TestAppendSession_CreateSubmitFutureReleasesCapacityWhenEnqueueRejected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	prepared, size, err := prepareAppendInput(&AppendInput{
+		Records: []AppendRecord{{Body: []byte("x")}},
+	})
+	if err != nil {
+		t.Fatalf("prepare append input failed: %v", err)
+	}
+
+	session := &AppendSession{
+		streamClient: newTestStreamClientForAppend(DefaultRetryConfig),
+		capacity:     newCapacityTracker(1024, 1),
+		wakeup:       make(chan struct{}, 1),
+	}
+	session.closing.Store(true)
+
+	future := session.createSubmitFuture(prepared, size)
+
+	_, err = future.Wait(ctx)
+	if !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("expected ErrSessionClosed, got %v", err)
+	}
+
+	session.capacity.mu.Lock()
+	curBytes := session.capacity.curBytes
+	curItems := session.capacity.curItems
+	session.capacity.mu.Unlock()
+	if curBytes != 0 || curItems != 0 {
+		t.Fatalf("expected reserved capacity to be released, got bytes=%d items=%d", curBytes, curItems)
+	}
+}
+
 func TestAppendSession_CloseWithEmptyQueue(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
- reject capacity-reserved submits that race with session shutdown before they can enter the inflight queue
- release reserved capacity when shutdown rejects a pending submit
- add regression coverage for the late-enqueue and capacity-release paths

## Testing
- env GOCACHE=/tmp/go-build go test ./...
- env GOCACHE=/tmp/go-build go test -race ./s2 -run 'TestAppendSession_CloseRejectsLateReservedEnqueue|TestAppendSession_CreateSubmitFutureReleasesCapacityWhenEnqueueRejected' -count=1