### PR TITLE
fix: wait for worker shutdown before removing from map

### DIFF
--- a/s2-bentobox/multi_stream_input.go
+++ b/s2-bentobox/multi_stream_input.go
@@ -152,6 +152,7 @@ managerLoop:
 			if _, found := newStreamsSet[stream]; !found {
 				config.Logger.With("stream", stream).Warn("Not reading from S2 source anymore")
 				worker.Close()
+				worker.Wait()
 				delete(existingWorkers, stream)
 			}
 		}


### PR DESCRIPTION
## Summary
Added a `Wait()` call after closing a worker to ensure proper synchronization during worker shutdown in the multi-stream input manager.

## Key Changes
- Added `worker.Wait()` call immediately after `worker.Close()` when removing a stream from the active workers set
- This ensures the worker has fully completed its shutdown sequence before the worker reference is deleted from the `existingWorkers` map

## Implementation Details
The change ensures proper cleanup ordering in the manager loop when a stream is no longer present in the new streams set. By waiting for the worker to complete shutdown before removing it from the map, we prevent potential race conditions and ensure graceful termination of stream processing.

https://claude.ai/code/session_01QjtV1aSx89aYvZWnpHYRyY