### PR TITLE
fix(bento): return on session error in streamSourceRecvLoop

### DIFF
--- a/s2-bentobox/multi_stream_input.go
+++ b/s2-bentobox/multi_stream_input.go
@@ -243,7 +243,7 @@ func streamSourceRecvLoop(
 				return
 			}
 
-			continue
+			return
 		}
 
 		select {


### PR DESCRIPTION
closes #176

## Summary

- After sending a session error to the consumer, `streamSourceRecvLoop` called `continue` and immediately retried `ReadBatch` on the same broken session
- A failed session returns from `ReadBatch` without blocking, so this created a tight busy loop flooding the input channel with millions of errors per second and pegging CPU at 100%
- Fix: change `continue` to `return` so the loop exits and `streamSource` handles reconnection with backoff

## Test plan

- [ ] Confirm that a persistent session error causes `streamSource` to reconnect with backoff rather than spinning
- [ ] Confirm that transient errors are still surfaced to the consumer before the session is torn down
- [ ] Confirm normal read loop behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)