### PR TITLE
Migrate default basin endpoint to b.s2.dev

### DIFF
--- a/s2/client.go
+++ b/s2/client.go
@@ -120,7 +120,7 @@ func New(accessToken string, opts *ClientOptions) *Client {
 	makeBasinBaseURL := opts.MakeBasinBaseURL
 	if makeBasinBaseURL == nil {
 		makeBasinBaseURL = func(basin string) string {
-			return fmt.Sprintf("https://%s.b.aws.s2.dev/v1", basin)
+			return fmt.Sprintf("https://%s.b.s2.dev/v1", basin)
 		}
 	} else {
 		makeBasinBaseURL = func(basin string) string {


### PR DESCRIPTION
## Summary
- Updates the hardcoded default basin endpoint from `b.aws.s2.dev` to `b.s2.dev` in `MakeBasinBaseURL`
- The `s2-specs` openapi.json was already updated via #242

## Test plan
- [ ] Verify default basin URL resolves correctly
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)