### PR TITLE
fix: validate access token ID length by bytes, not runes

### DIFF
--- a/s2/access_tokens.go
+++ b/s2/access_tokens.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"unicode/utf8"
 )
 
 type AccessTokensClient struct {
@@ -160,9 +159,9 @@ func (a *AccessTokensClient) Revoke(ctx context.Context, args RevokeAccessTokenA
 }
 
 func validateAccessTokenID(id AccessTokenID) error {
-	length := utf8.RuneCountInString(string(id))
+	length := len(id)
 	if length < 1 || length > 96 {
-		return fmt.Errorf("access token ID must be between 1 and 96 characters")
+		return fmt.Errorf("access token ID must be between 1 and 96 bytes")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `validateAccessTokenID` was counting runes (`utf8.RuneCountInString`) while the OpenAPI/SDK spec and server enforce a 96-**byte** limit. A multi-byte UTF-8 ID with ≤96 runes but >96 bytes would pass client validation only to be rejected server-side.
- Switch to `len(id)` and update the error message to say "bytes". Mirrors `validateStreamName` (fixed in ba739f6) and the Rust SDK (`s2-common::types::access`, which uses `id.len()` against `MAX_ACCESS_TOKEN_ID_LEN`).
- Closes #268.

## Test plan
- [x] `go build ./... && go vet ./...`
- [ ] Confirm existing access-token tests still pass in CI
- [ ] (optional follow-up) add a regression test exercising a >96-byte / ≤96-rune ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)