### PR TITLE
fix: scope tail watchdog to network wait only

### DIFF
--- a/s2/read.go
+++ b/s2/read.go
@@ -464,14 +464,13 @@ func (r *streamReader) runOnce(ctx context.Context, opts *ReadOptions) error {
 	tailTimer := time.NewTimer(tailWatchdogTimeout)
 	defer tailTimer.Stop()
 
-	resetTailTimer := func() {
+	stopTailTimer := func() {
 		if !tailTimer.Stop() {
 			select {
 			case <-tailTimer.C:
 			default:
 			}
 		}
-		tailTimer.Reset(tailWatchdogTimeout)
 	}
 
 	type frameResult struct {
@@ -508,6 +507,12 @@ func (r *streamReader) runOnce(ctx context.Context, opts *ReadOptions) error {
 				Code:    "TIMEOUT",
 			}
 		case fr = <-frameCh:
+			// Network wait satisfied: stop the watchdog so consumer-delivery
+			// time (handleRecord can block on the records channel) does not
+			// count toward it. The timer is reset at the end of the loop body
+			// when the next network wait begins. Mirrors the Rust SDK's
+			// `timeout(20s, batches.next())` scope, which excludes yield.
+			stopTailTimer()
 		}
 
 		if fr.err != nil {
@@ -539,7 +544,6 @@ func (r *streamReader) runOnce(ctx context.Context, opts *ReadOptions) error {
 			return err
 		}
 		logInfo(r.logger, "s2 read session batch", "stream", string(r.streamClient.name), "records", len(batch.Records))
-		resetTailTimer()
 
 		if batch.Tail != nil {
 			logInfo(r.logger, "s2 read session batch tail", "stream", string(r.streamClient.name), "seq_num", batch.Tail.SeqNum)
@@ -559,6 +563,8 @@ func (r *streamReader) runOnce(ctx context.Context, opts *ReadOptions) error {
 				return err
 			}
 		}
+
+		tailTimer.Reset(tailWatchdogTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The 20s tail watchdog was reset right after parsing a frame and *before* the per-record `handleRecord` loop. `handleRecord` blocks on `recordsCh <- record`, so a slow consumer kept the timer running during delivery. With `frameCh` having capacity 1 (the reader goroutine can buffer the next frame in the meantime) and Go's `select` choosing randomly among ready cases, the next iteration could pick `tailTimer.C` and return a spurious 408 `TIMEOUT` even with a frame buffered.
- Stop the timer the instant a frame is received and reset it only after the record loop completes, so it covers strictly the network wait between frames.
- Matches the Rust SDK contract: `timeout(Duration::from_secs(20), batches.next())` in `sdk/src/session/read.rs` scopes only the network read; the yield/delivery is outside it.
- Closes #266.

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] `go test -short -race -count=1 ./s2/...`
- [ ] No new regression test — `tailWatchdogTimeout` is a package-level const, so a fast deterministic test would need an injectable timeout. Happy to follow up with a small refactor + test if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)