### PR TITLE
feat: add aws:us-west-2 and aws:eu-north-1 basin scopes

### DIFF
--- a/s2/types.go
+++ b/s2/types.go
@@ -32,7 +32,9 @@ type StorageClass string
 type TimestampingMode string
 
 const (
-	BasinScopeAwsUsEast1 BasinScope = "aws:us-east-1"
+	BasinScopeAwsUsEast1  BasinScope = "aws:us-east-1"
+	BasinScopeAwsUsWest2  BasinScope = "aws:us-west-2"
+	BasinScopeAwsEuNorth1 BasinScope = "aws:eu-north-1"
 )
 
 const (
@@ -635,6 +637,7 @@ type CreateBasinArgs struct {
 	// Basin configuration.
 	Config *BasinConfig `json:"config,omitempty"`
 	// Basin scope.
+	// If omitted, defaults to `aws:us-east-1`.
 	Scope *BasinScope `json:"scope,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Add `BasinScopeAwsUsWest2` and `BasinScopeAwsEuNorth1` constants alongside the existing `BasinScopeAwsUsEast1`, picking up the new enum values from s2-specs `f43a620` (s2-streamstore/s2-specs#11).
- Surface the "defaults to `aws:us-east-1`" doc on `CreateBasinArgs.Scope`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)