### PR TITLE
fix: Iter Limit is a per-page hint, not a total cap

### DIFF
--- a/s2/access_tokens.go
+++ b/s2/access_tokens.go
@@ -47,22 +47,16 @@ func (a *AccessTokensClient) List(ctx context.Context, args *ListAccessTokensArg
 }
 
 // Iterate over access tokens.
+// Limit, when set, is the page size for each underlying List call, not a total cap.
+// Iteration drains all matching access tokens; break out of the loop to stop early, or use [AccessTokensClient.List] for a capped single-page result.
 func (a *AccessTokensClient) Iter(ctx context.Context, args *ListAccessTokensArgs) *AccessTokenIterator {
 	base := ListAccessTokensArgs{}
 	if args != nil {
 		base = *args
 	}
-	remaining := copyLimit(base.Limit)
-	base.Limit = nil
 	fetch := func(ctx context.Context, startAfter string) (*pagedResponse[AccessTokenInfo], error) {
-		if remainingDepleted(remaining) {
-			return &pagedResponse[AccessTokenInfo]{}, nil
-		}
 		params := base
 		params.StartAfter = startAfter
-		if limit, ok := nextRequestLimit(remaining); ok {
-			params.Limit = &limit
-		}
 		resp, err := a.List(ctx, &params)
 		if err != nil {
 			return nil, err
@@ -70,9 +64,6 @@ func (a *AccessTokensClient) Iter(ctx context.Context, args *ListAccessTokensArg
 		next := ""
 		if resp.HasMore && len(resp.AccessTokens) > 0 {
 			next = string(resp.AccessTokens[len(resp.AccessTokens)-1].ID)
-		}
-		if consumeRemaining(remaining, len(resp.AccessTokens)) {
-			next = ""
 		}
 		return &pagedResponse[AccessTokenInfo]{items: resp.AccessTokens, nextKey: next}, nil
 	}

--- a/s2/basin_integration_test.go
+++ b/s2/basin_integration_test.go
@@ -279,6 +279,38 @@ func TestListBasins_LimitZero(t *testing.T) {
 	t.Logf("Listed %d basins with limit=0", len(resp.Basins))
 }
 
+func TestIterBasins_LimitZero(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	t.Log("Testing: Iter with Limit=0 drains all basins")
+
+	client := testClient(t)
+
+	iterAll := client.Basins.Iter(ctx, nil)
+	allCount := 0
+	for iterAll.Next() {
+		allCount++
+	}
+	if err := iterAll.Err(); err != nil {
+		t.Fatalf("Iter (no limit): %v", err)
+	}
+
+	zero := 0
+	iterZero := client.Basins.Iter(ctx, &s2.ListBasinsArgs{Limit: &zero})
+	zeroCount := 0
+	for iterZero.Next() {
+		zeroCount++
+	}
+	if err := iterZero.Err(); err != nil {
+		t.Fatalf("Iter (Limit=0): %v", err)
+	}
+
+	if zeroCount != allCount {
+		t.Errorf("Iter(Limit=0) returned %d items; Iter(nil) returned %d. Limit=0 should be 'no limit'.",
+			zeroCount, allCount)
+	}
+}
+
 func TestListBasins_LimitExceeds1000(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()

--- a/s2/basins.go
+++ b/s2/basins.go
@@ -49,6 +49,8 @@ func (b *BasinsClient) List(ctx context.Context, args *ListBasinsArgs) (*ListBas
 }
 
 // Iterate over basins.
+// Limit, when set, is the page size for each underlying List call, not a total cap.
+// Iteration drains all matching basins; break out of the loop to stop early, or use [BasinsClient.List] for a capped single-page result.
 // By default, basins that are being deleted are excluded. Set IncludeDeleted to true to include them.
 func (b *BasinsClient) Iter(ctx context.Context, args *ListBasinsArgs) *BasinsIterator {
 	base := ListBasinsArgs{}
@@ -56,22 +58,14 @@ func (b *BasinsClient) Iter(ctx context.Context, args *ListBasinsArgs) *BasinsIt
 		base = *args
 	}
 	includeDeleted := base.IncludeDeleted
-	remaining := copyLimit(base.Limit)
-	base.Limit = nil
 	fetch := func(ctx context.Context, startAfter string) (*pagedResponse[BasinInfo], error) {
-		if remainingDepleted(remaining) {
-			return &pagedResponse[BasinInfo]{}, nil
-		}
 		params := base
 		params.StartAfter = startAfter
-		if limit, ok := nextRequestLimit(remaining); ok {
-			params.Limit = &limit
-		}
 		resp, err := b.List(ctx, &params)
 		if err != nil {
 			return nil, err
 		}
-		// Filter out deleted basins unless IncludeDeleted is true
+		// Filter out deleted basins unless IncludeDeleted is true.
 		basins := resp.Basins
 		if !includeDeleted {
 			basins = make([]BasinInfo, 0, len(resp.Basins))
@@ -84,9 +78,6 @@ func (b *BasinsClient) Iter(ctx context.Context, args *ListBasinsArgs) *BasinsIt
 		next := ""
 		if resp.HasMore && len(resp.Basins) > 0 {
 			next = string(resp.Basins[len(resp.Basins)-1].Name)
-		}
-		if consumeRemaining(remaining, len(basins)) {
-			next = ""
 		}
 		return &pagedResponse[BasinInfo]{items: basins, nextKey: next}, nil
 	}

--- a/s2/iterator.go
+++ b/s2/iterator.go
@@ -4,42 +4,6 @@ import (
 	"context"
 )
 
-const maxListPageSize = 1000
-
-func copyLimit(limit *int) *int {
-	if limit == nil {
-		return nil
-	}
-	val := *limit
-	return &val
-}
-
-func remainingDepleted(remaining *int) bool {
-	return remaining != nil && *remaining <= 0
-}
-
-func nextRequestLimit(remaining *int) (int, bool) {
-	if remaining == nil {
-		return 0, false
-	}
-	if *remaining <= 0 {
-		return 0, false
-	}
-	limit := *remaining
-	if limit > maxListPageSize {
-		limit = maxListPageSize
-	}
-	return limit, true
-}
-
-func consumeRemaining(remaining *int, consumed int) bool {
-	if remaining == nil {
-		return false
-	}
-	*remaining -= consumed
-	return *remaining <= 0
-}
-
 type pager[T any] struct {
 	ctx        context.Context
 	fetch      func(context.Context, string) (*pagedResponse[T], error)

--- a/s2/streams.go
+++ b/s2/streams.go
@@ -48,6 +48,8 @@ func (s *StreamsClient) List(ctx context.Context, args *ListStreamsArgs) (*ListS
 }
 
 // Iterate over streams in a basin.
+// Limit, when set, is the page size for each underlying List call, not a total cap.
+// Iteration drains all matching streams; break out of the loop to stop early, or use [StreamsClient.List] for a capped single-page result.
 // By default, streams that are being deleted are excluded. Set IncludeDeleted to true to include them.
 func (s *StreamsClient) Iter(ctx context.Context, args *ListStreamsArgs) *StreamsIterator {
 	base := ListStreamsArgs{}
@@ -55,22 +57,14 @@ func (s *StreamsClient) Iter(ctx context.Context, args *ListStreamsArgs) *Stream
 		base = *args
 	}
 	includeDeleted := base.IncludeDeleted
-	remaining := copyLimit(base.Limit)
-	base.Limit = nil
 	fetch := func(ctx context.Context, startAfter string) (*pagedResponse[StreamInfo], error) {
-		if remainingDepleted(remaining) {
-			return &pagedResponse[StreamInfo]{}, nil
-		}
 		params := base
 		params.StartAfter = startAfter
-		if limit, ok := nextRequestLimit(remaining); ok {
-			params.Limit = &limit
-		}
 		resp, err := s.List(ctx, &params)
 		if err != nil {
 			return nil, err
 		}
-		// Filter out deleted streams unless IncludeDeleted is true
+		// Filter out deleted streams unless IncludeDeleted is true.
 		streams := resp.Streams
 		if !includeDeleted {
 			streams = make([]StreamInfo, 0, len(resp.Streams))
@@ -83,9 +77,6 @@ func (s *StreamsClient) Iter(ctx context.Context, args *ListStreamsArgs) *Stream
 		next := ""
 		if resp.HasMore && len(resp.Streams) > 0 {
 			next = string(resp.Streams[len(resp.Streams)-1].Name)
-		}
-		if consumeRemaining(remaining, len(streams)) {
-			next = ""
 		}
 		return &pagedResponse[StreamInfo]{items: streams, nextKey: next}, nil
 	}


### PR DESCRIPTION
## Summary
- `Iter` treated `Limit` as a client-side total cap. The pre-fetch guard `remainingDepleted` used `*remaining <= 0`, so `Limit: ptr(0)` short-circuited before any HTTP call and the iterator returned zero items. Meanwhile `List(Limit=0)` honors the spec's "0 treated as default" behavior (`docs/test_basins_api.md:125`), so `List` and `Iter` diverged on the same input.
- Drop the cap machinery (`copyLimit`, `remainingDepleted`, `nextRequestLimit`, `consumeRemaining`) and forward `Limit` through to every underlying `List` call as a per-page hint. Iteration drains all matching items regardless of `Limit`; callers wanting a capped result use `List` or break out of the loop. Doc comments on `BasinsClient.Iter`, `StreamsClient.Iter`, and `AccessTokensClient.Iter` updated to spell this out.
- Closes #270.

### Behavior

| Input | Before | After |
|---|---|---|
| `Iter(nil)` | drain all | drain all (unchanged) |
| `Iter(Limit=0)` | 0 items, no HTTP call | drain all, server-default page size |
| `Iter(Limit=N)` for N>0 | up to N items total | drain all, in pages of N |

`List` behavior is unchanged.

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] Added `TestIterBasins_LimitZero` asserting `Iter(Limit: ptr(0))` yields the same count as `Iter(nil)`. Runs in `s2-integration` (cloud) and `s2-lite-integration` (local) CI jobs.
- [ ] Existing `TestListBasins_Iterator`, `TestListStreams_Iterator`, `TestListAccessTokens_Iterator` still pass (they don't assert on the cap, just count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)