### PR TITLE
fix(bentobox): handle 416 in recv loop and clear cache on stream removal

### DIFF
--- a/s2-bentobox/input.go
+++ b/s2-bentobox/input.go
@@ -82,6 +82,14 @@ func (s *seqNumCache) Set(ctx context.Context, stream string, seqNum uint64) err
 	return nil
 }
 
+// Drops the in-memory entry for stream so a subsequent Get re-reads the inner
+// durable cache. Used when a stream leaves the configured set: if it returns
+// later (possibly delete/recreated), we don't shadow the inner cache with a
+// stale value held only in memory.
+func (s *seqNumCache) Forget(stream string) {
+	s.mem.Remove(stream)
+}
+
 type InputStreams interface {
 	list(ctx context.Context, basin *s2.BasinClient) ([]string, error)
 }

--- a/s2-bentobox/multi_stream_input.go
+++ b/s2-bentobox/multi_stream_input.go
@@ -253,6 +253,9 @@ func streamSourceRecvLoop(
 				if setErr := cache.Set(ctx, stream, rangeErr.Tail.SeqNum); setErr != nil {
 					logger.With("stream", stream, "error", setErr).
 						Error("Failed to reset cached sequence number after 416")
+					// Drop the stale in-memory entry so the next reconnect doesn't
+					// shadow the inner cache and tight-loop on 416.
+					cache.Forget(stream)
 				}
 				return
 			}

--- a/s2-bentobox/multi_stream_input.go
+++ b/s2-bentobox/multi_stream_input.go
@@ -154,6 +154,7 @@ managerLoop:
 				worker.Close()
 				worker.Wait()
 				delete(existingWorkers, stream)
+				cache.Forget(stream)
 			}
 		}
 	}
@@ -201,14 +202,6 @@ func streamSource(
 
 		input, err := connectStreamInput(ctx, basin, cache, logger, stream, maxInflight, inputStartSeqNum)
 		if err != nil {
-			var rangeErr *s2.RangeNotSatisfiableError
-			if errors.As(err, &rangeErr) && rangeErr.Tail != nil {
-				logger.With("stream", stream, "tail_seq_num", rangeErr.Tail.SeqNum).
-					Warn("Cached position beyond stream tail, resetting to tail")
-				_ = cache.Set(ctx, stream, rangeErr.Tail.SeqNum)
-				continue
-			}
-
 			logger.With("error", err, "stream", stream).Error("Failed to connect, retrying.")
 
 			jitter := time.Duration(rand.Int63n(int64(10 * time.Millisecond)))
@@ -217,13 +210,21 @@ func streamSource(
 			continue
 		}
 
-		streamSourceRecvLoop(ctx, input, stream, inputStream, logger)
+		streamSourceRecvLoop(ctx, input, cache, stream, inputStream, logger)
 	}
+}
+
+// Surface of *streamInput that streamSourceRecvLoop needs. Defined here so
+// tests can drive the loop with a fake reader.
+type recvBatchSource interface {
+	ReadBatch(ctx context.Context) ([]s2.SequencedRecord, AckFunc, error)
+	Close(ctx context.Context) error
 }
 
 func streamSourceRecvLoop(
 	ctx context.Context,
-	input *streamInput,
+	input recvBatchSource,
+	cache *seqNumCache,
 	stream string,
 	inputStream chan<- recvOutput,
 	logger Logger,
@@ -242,6 +243,17 @@ func streamSourceRecvLoop(
 			if errors.Is(err, ErrInputClosed) {
 				logger.With("stream", stream).Debug("Restarting source")
 
+				return
+			}
+
+			var rangeErr *s2.RangeNotSatisfiableError
+			if errors.As(err, &rangeErr) && rangeErr.Tail != nil {
+				logger.With("stream", stream, "tail_seq_num", rangeErr.Tail.SeqNum).
+					Warn("Cached position beyond stream tail, resetting to tail")
+				if setErr := cache.Set(ctx, stream, rangeErr.Tail.SeqNum); setErr != nil {
+					logger.With("stream", stream, "error", setErr).
+						Error("Failed to reset cached sequence number after 416")
+				}
 				return
 			}
 

--- a/s2-bentobox/multi_stream_input_test.go
+++ b/s2-bentobox/multi_stream_input_test.go
@@ -249,3 +249,46 @@ func (m *mapCache) Set(_ context.Context, stream string, seqNum uint64) error {
 	m.data[stream] = seqNum
 	return nil
 }
+
+type failingSetCache struct {
+	getValue uint64
+	setErr   error
+}
+
+func (f *failingSetCache) Get(context.Context, string) (uint64, error) {
+	return f.getValue, nil
+}
+
+func (f *failingSetCache) Set(context.Context, string, uint64) error {
+	return f.setErr
+}
+
+func TestStreamSourceRecvLoopForgetsStaleMemEntryWhenSetFails(t *testing.T) {
+	const stream = "demo"
+	const stale uint64 = 42
+	const tailSeqNum uint64 = 9001
+
+	inner := &failingSetCache{getValue: stale, setErr: errors.New("durable cache write failed")}
+	cache := newSeqNumCache(inner, silentLogger{})
+
+	// Warm the in-memory layer with the stale value (simulates prior successful
+	// Set that has since become stale relative to the stream tail).
+	if _, err := cache.Get(context.Background(), stream); err != nil {
+		t.Fatalf("warm cache: %v", err)
+	}
+
+	rangeErr := &s2.RangeNotSatisfiableError{
+		S2Error: &s2.S2Error{Status: 416, Code: "RANGE_NOT_SATISFIABLE", Origin: "server"},
+		Tail:    &s2.StreamPosition{SeqNum: tailSeqNum},
+	}
+	src := &fakeBatchSource{results: []readResult{{err: rangeErr}}}
+	inputStream := make(chan recvOutput, 1)
+
+	streamSourceRecvLoop(context.Background(), src, cache, stream, inputStream, silentLogger{})
+
+	// In-mem must be cleared so the next reconnect falls through to inner.Get
+	// instead of returning the stale value and tight-looping on 416.
+	if _, ok := cache.mem.Get(stream); ok {
+		t.Fatal("expected in-memory cache entry to be cleared after failed Set")
+	}
+}

--- a/s2-bentobox/multi_stream_input_test.go
+++ b/s2-bentobox/multi_stream_input_test.go
@@ -1,0 +1,251 @@
+package bentobox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/s2-streamstore/s2-sdk-go/s2"
+)
+
+type fakeBatchSource struct {
+	mu       sync.Mutex
+	results  []readResult
+	pos      int
+	closeErr error
+	closed   bool
+}
+
+type readResult struct {
+	batch   []s2.SequencedRecord
+	ackFunc AckFunc
+	err     error
+}
+
+func (f *fakeBatchSource) ReadBatch(ctx context.Context) ([]s2.SequencedRecord, AckFunc, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.pos >= len(f.results) {
+		return nil, nil, ErrInputClosed
+	}
+	r := f.results[f.pos]
+	f.pos++
+	return r.batch, r.ackFunc, r.err
+}
+
+func (f *fakeBatchSource) Close(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return f.closeErr
+}
+
+type silentLogger struct{}
+
+func (silentLogger) Tracef(string, ...any)            {}
+func (silentLogger) Trace(string)                     {}
+func (silentLogger) Debugf(string, ...any)            {}
+func (silentLogger) Debug(string)                     {}
+func (silentLogger) Infof(string, ...any)             {}
+func (silentLogger) Info(string)                      {}
+func (silentLogger) Warnf(string, ...any)             {}
+func (silentLogger) Warn(string)                      {}
+func (silentLogger) Errorf(string, ...any)            {}
+func (silentLogger) Error(string)                     {}
+func (silentLogger) With(...any) Logger               { return silentLogger{} }
+
+func TestStreamSourceRecvLoopResetsCacheOn416(t *testing.T) {
+	const stream = "demo"
+	const tailSeqNum uint64 = 9001
+
+	rangeErr := &s2.RangeNotSatisfiableError{
+		S2Error: &s2.S2Error{
+			Status: 416,
+			Code:   "RANGE_NOT_SATISFIABLE",
+			Origin: "server",
+		},
+		Tail: &s2.StreamPosition{SeqNum: tailSeqNum},
+	}
+
+	src := &fakeBatchSource{
+		results: []readResult{{err: rangeErr}},
+	}
+	cache := newSeqNumCache(nil, silentLogger{})
+	if err := cache.Set(context.Background(), stream, 42); err != nil {
+		t.Fatalf("seed cache failed: %v", err)
+	}
+
+	inputStream := make(chan recvOutput, 1)
+	done := make(chan struct{})
+	go func() {
+		streamSourceRecvLoop(context.Background(), src, cache, stream, inputStream, silentLogger{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("recv loop did not return on 416")
+	}
+
+	got, err := cache.Get(context.Background(), stream)
+	if err != nil {
+		t.Fatalf("cache.Get after 416: %v", err)
+	}
+	if got != tailSeqNum {
+		t.Fatalf("expected cache reset to tail %d, got %d", tailSeqNum, got)
+	}
+
+	select {
+	case out := <-inputStream:
+		t.Fatalf("416 should be swallowed; got recvOutput %+v", out)
+	default:
+	}
+
+	if !src.closed {
+		t.Fatal("recv loop should close the input")
+	}
+}
+
+func TestStreamSourceRecvLoopForwardsOtherErrors(t *testing.T) {
+	const stream = "demo"
+	otherErr := errors.New("boom")
+
+	src := &fakeBatchSource{
+		results: []readResult{{err: otherErr}},
+	}
+	cache := newSeqNumCache(nil, silentLogger{})
+	if err := cache.Set(context.Background(), stream, 42); err != nil {
+		t.Fatalf("seed cache failed: %v", err)
+	}
+
+	inputStream := make(chan recvOutput, 1)
+	done := make(chan struct{})
+	go func() {
+		streamSourceRecvLoop(context.Background(), src, cache, stream, inputStream, silentLogger{})
+		close(done)
+	}()
+
+	select {
+	case out := <-inputStream:
+		if !errors.Is(out.Err, otherErr) {
+			t.Fatalf("expected forwarded err, got %v", out.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected error to be forwarded to inputStream")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("recv loop did not return after forwarding error")
+	}
+
+	got, err := cache.Get(context.Background(), stream)
+	if err != nil {
+		t.Fatalf("cache.Get: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("non-416 errors should not touch cache; got %d", got)
+	}
+}
+
+func TestStreamSourceRecvLoopForwards416WhenTailMissing(t *testing.T) {
+	const stream = "demo"
+
+	rangeErr := &s2.RangeNotSatisfiableError{
+		S2Error: &s2.S2Error{Status: 416, Code: "RANGE_NOT_SATISFIABLE", Origin: "server"},
+	}
+
+	src := &fakeBatchSource{
+		results: []readResult{{err: rangeErr}},
+	}
+	cache := newSeqNumCache(nil, silentLogger{})
+	if err := cache.Set(context.Background(), stream, 42); err != nil {
+		t.Fatalf("seed cache failed: %v", err)
+	}
+
+	inputStream := make(chan recvOutput, 1)
+	done := make(chan struct{})
+	go func() {
+		streamSourceRecvLoop(context.Background(), src, cache, stream, inputStream, silentLogger{})
+		close(done)
+	}()
+
+	select {
+	case out := <-inputStream:
+		var got *s2.RangeNotSatisfiableError
+		if !errors.As(out.Err, &got) {
+			t.Fatalf("expected RangeNotSatisfiableError forwarded, got %T", out.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected 416 without tail to be forwarded")
+	}
+
+	<-done
+
+	got, err := cache.Get(context.Background(), stream)
+	if err != nil {
+		t.Fatalf("cache.Get: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("cache should be untouched without Tail; got %d", got)
+	}
+}
+
+func TestSeqNumCacheForgetDropsInMemoryEntry(t *testing.T) {
+	cache := newSeqNumCache(nil, silentLogger{})
+	if err := cache.Set(context.Background(), "s", 7); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	cache.Forget("s")
+
+	_, err := cache.Get(context.Background(), "s")
+	if !errors.Is(err, ErrNoCacheEntry) {
+		t.Fatalf("expected ErrNoCacheEntry after Forget, got %v", err)
+	}
+}
+
+func TestSeqNumCacheForgetDoesNotTouchInner(t *testing.T) {
+	inner := &mapCache{data: map[string]uint64{"s": 11}}
+	cache := newSeqNumCache(inner, silentLogger{})
+
+	if _, err := cache.Get(context.Background(), "s"); err != nil {
+		t.Fatalf("warm cache: %v", err)
+	}
+
+	cache.Forget("s")
+
+	got, err := cache.Get(context.Background(), "s")
+	if err != nil {
+		t.Fatalf("get after forget: %v", err)
+	}
+	if got != 11 {
+		t.Fatalf("expected inner durable value 11, got %d", got)
+	}
+}
+
+type mapCache struct {
+	mu   sync.Mutex
+	data map[string]uint64
+}
+
+func (m *mapCache) Get(_ context.Context, stream string) (uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.data[stream]
+	if !ok {
+		return 0, ErrNoCacheEntry
+	}
+	return v, nil
+}
+
+func (m *mapCache) Set(_ context.Context, stream string, seqNum uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[stream] = seqNum
+	return nil
+}


### PR DESCRIPTION
## Summary
- The 416 handler added in #261 was placed after `connectStreamInput`, but `ReadSession` returns synchronously with nil and runs the request asynchronously, so a 416 never surfaces there. The block was unreachable, and the original infinite-416-loop scenario from #247 was never actually fixed.
- This PR moves the handler into `streamSourceRecvLoop`, where 416 actually surfaces from `ReadBatch` via `session.Err()`. On 416 with a tail it resets the cache to `Tail.SeqNum` and returns so the outer loop reconnects from the valid position. On 416 without a tail (no recovery info), it forwards to the consumer.
- Also clears the in-memory cache entry when a stream is removed from the configured set, so a re-added stream doesn't read a stale position out of the in-mem layer (the second half of #247).

Closes #271
Closes #247

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `task lint`
- [x] New unit tests cover: 416-with-tail recovery, non-416 errors still forwarded, 416-without-tail still forwarded, and `Forget` semantics (drops mem only, leaves inner durable cache intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)