### PR TITLE
fix(append): dedupe handleSessionError so one failure consumes one attempt

### DIFF
--- a/s2/append.go
+++ b/s2/append.go
@@ -81,6 +81,7 @@ type transportAppendSession struct {
 	conn          *http.Response
 	requestWriter io.WriteCloser
 	pendingWrites int
+	terminalErr   error
 }
 
 func (s *StreamClient) createAppendSession(ctx context.Context) (*transportAppendSession, error) {
@@ -185,6 +186,7 @@ func (p *transportAppendSession) reportError(err error) {
 	if err == nil {
 		return
 	}
+	p.recordTerminalError(err)
 	select {
 	case <-p.closed:
 	case p.errorsCh <- err:
@@ -192,8 +194,37 @@ func (p *transportAppendSession) reportError(err error) {
 	}
 }
 
+func (p *transportAppendSession) reportErrorIfOpen(err error) {
+	select {
+	case <-p.closed:
+		return
+	default:
+		p.reportError(err)
+	}
+}
+
+func (p *transportAppendSession) recordTerminalError(err error) {
+	if err == nil {
+		return
+	}
+	p.mu.Lock()
+	if p.terminalErr == nil {
+		p.terminalErr = err
+	}
+	p.mu.Unlock()
+}
+
+func (p *transportAppendSession) terminalError() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.terminalErr
+}
+
 func (p *transportAppendSession) appendInput(input *AppendInput) error {
 	if p.isClosed() {
+		if err := p.terminalError(); err != nil {
+			return err
+		}
 		return ErrSessionClosed
 	}
 
@@ -210,12 +241,18 @@ func (p *transportAppendSession) appendInput(input *AppendInput) error {
 	writer := p.requestWriter
 	p.mu.Unlock()
 	if writer == nil {
+		if err := p.terminalError(); err != nil {
+			return err
+		}
 		return ErrSessionClosed
 	}
 
 	p.markWriteSignalled()
 	_, err = writer.Write(frame)
 	if err != nil {
+		if terminalErr := p.terminalError(); terminalErr != nil {
+			return terminalErr
+		}
 		if p.isClosed() {
 			return ErrSessionClosed
 		}
@@ -289,19 +326,12 @@ func (p *transportAppendSession) readAcksLoop(conn *http.Response) {
 			if isExpectedFrameReadError(err) {
 				return
 			}
-			select {
-			case <-p.closed:
-				return
-			case p.errorsCh <- fmt.Errorf("read frame error: %w", err):
-			}
+			p.reportErrorIfOpen(fmt.Errorf("read frame error: %w", err))
 			return
 		}
 
 		if err := p.handleFrame(frame); err != nil {
-			select {
-			case p.errorsCh <- err:
-			case <-p.closed:
-			}
+			p.reportErrorIfOpen(err)
 			return
 		}
 	}

--- a/s2/append_session.go
+++ b/s2/append_session.go
@@ -539,14 +539,26 @@ func (r *AppendSession) handleSessionError(failedSession *transportAppendSession
 		return
 	}
 
+	// Atomically claim ownership of the failed session. Both the write path
+	// and the read-acks path can call into here for the same transport
+	// failure; without the claim, both proceed past the old read-only
+	// isCurrent check, log twice, increment currentAttempt twice, and
+	// double-schedule a retry. Whichever caller swaps currentSession from
+	// failedSession to nil wins; the loser bails.
 	if failedSession != nil {
-		r.sessionMu.RLock()
-		isCurrent := r.currentSession == failedSession
-		r.sessionMu.RUnlock()
-		if !isCurrent {
+		r.sessionMu.Lock()
+		if r.currentSession != failedSession {
+			r.sessionMu.Unlock()
 			r.closeSessionIfUnused(failedSession)
 			return
 		}
+		r.currentSession = nil
+		r.sessionMu.Unlock()
+		r.closeSessionIfUnused(failedSession)
+	} else {
+		r.sessionMu.Lock()
+		r.currentSession = nil
+		r.sessionMu.Unlock()
 	}
 
 	logError(r.streamClient.logger, "append session transport error",
@@ -569,19 +581,6 @@ func (r *AppendSession) handleSessionError(failedSession *transportAppendSession
 		}
 	}
 
-	if failedSession != nil {
-		r.sessionMu.Lock()
-		if r.currentSession == failedSession {
-			r.currentSession = nil
-		}
-		r.sessionMu.Unlock()
-		r.closeSessionIfUnused(failedSession)
-	} else {
-		r.sessionMu.Lock()
-		r.currentSession = nil
-		r.sessionMu.Unlock()
-	}
-
 	var s2Err *S2Error
 	if errors.As(err, &s2Err) && !s2Err.IsRetryable() {
 		logError(r.streamClient.logger, "append session error not retryable",
@@ -597,11 +596,9 @@ func (r *AppendSession) handleSessionError(failedSession *transportAppendSession
 		maxAttempts = 1
 	}
 
-	r.stateMu.RLock()
-	currentAttempt := r.currentAttempt
-	r.stateMu.RUnlock()
-
-	if currentAttempt >= maxAttempts-1 {
+	r.stateMu.Lock()
+	if r.currentAttempt >= maxAttempts-1 {
+		r.stateMu.Unlock()
 		logError(r.streamClient.logger, "append session max attempts exhausted",
 			"stream", string(r.streamClient.name),
 			"attempts", maxAttempts)
@@ -609,8 +606,6 @@ func (r *AppendSession) handleSessionError(failedSession *transportAppendSession
 			maxAttempts, err, ErrMaxAttemptsExhausted))
 		return
 	}
-
-	r.stateMu.Lock()
 	r.currentAttempt++
 	r.stateMu.Unlock()
 

--- a/s2/append_session_retry_test.go
+++ b/s2/append_session_retry_test.go
@@ -827,3 +827,88 @@ func TestAppendSession_HandleSessionErrorIsIdempotentAcrossConcurrentCalls(t *te
 		t.Fatalf("expected currentSession cleared after claim, still %p", current)
 	}
 }
+
+func TestAppendSession_WriteUnblockedByTerminalErrorUsesServerError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	retryCfg := &RetryConfig{
+		MaxAttempts:       5,
+		MinBaseDelay:      time.Millisecond,
+		MaxBaseDelay:      time.Millisecond,
+		AppendRetryPolicy: AppendRetryPolicyAll,
+	}
+
+	stream := newTestStreamClientForAppend(retryCfg)
+	writer := &blockingClosedPipeWriter{
+		started: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+	failed := newTransportSession(stream, writer)
+	session := &AppendSession{
+		streamClient:   stream,
+		options:        &AppendSessionOptions{RetryConfig: retryCfg},
+		capacity:       newCapacityTracker(1024, 1),
+		sessionRefs:    make(map[*transportAppendSession]int),
+		currentSession: failed,
+		pumpCtx:        ctx,
+		pumpCancel:     cancel,
+		closeDone:      make(chan struct{}),
+		wakeup:         make(chan struct{}, 1),
+	}
+	entry := &inflightEntry{
+		input:         &AppendInput{Records: []AppendRecord{{Body: []byte("x")}}},
+		expectedCount: 1,
+		meteredBytes:  1,
+		resultCh:      make(chan *inflightResult, 1),
+	}
+	session.inflightQueue = []*inflightEntry{entry}
+
+	done := make(chan struct{})
+	go func() {
+		session.submitInflightBatches()
+		close(done)
+	}()
+
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for append write to start")
+	}
+
+	terminalErr := &S2Error{
+		Message: "bad request",
+		Status:  400,
+		Origin:  "server",
+	}
+	failed.reportError(terminalErr)
+	if err := failed.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for submitInflightBatches to return")
+	}
+
+	select {
+	case result := <-entry.resultCh:
+		if result == nil || result.err == nil {
+			t.Fatalf("expected terminal error result, got %#v", result)
+		}
+		var s2Err *S2Error
+		if !errors.As(result.err, &s2Err) || s2Err.Status != 400 {
+			t.Fatalf("expected terminal S2Error status 400, got %v", result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for inflight entry to fail")
+	}
+
+	session.stateMu.RLock()
+	attempt := session.currentAttempt
+	session.stateMu.RUnlock()
+	if attempt != 0 {
+		t.Fatalf("non-retryable terminal error should not consume a retry attempt, got %d", attempt)
+	}
+}

--- a/s2/append_session_retry_test.go
+++ b/s2/append_session_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 )
@@ -766,5 +767,63 @@ func TestAppendSession_NoSideEffectsNoRetryWithNonIdempotentSentPipeline(t *test
 	}
 	if factoryCalls != 1 {
 		t.Fatalf("expected 1 session attempt, got %d", factoryCalls)
+	}
+}
+
+func TestAppendSession_HandleSessionErrorIsIdempotentAcrossConcurrentCalls(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	retryCfg := &RetryConfig{
+		MaxAttempts:       5,
+		MinBaseDelay:      time.Millisecond,
+		MaxBaseDelay:      time.Millisecond,
+		AppendRetryPolicy: AppendRetryPolicyAll,
+	}
+
+	stream := newTestStreamClientForAppend(retryCfg)
+	stream.appendSessionFactory = func(context.Context) (*transportAppendSession, error) {
+		return newTransportSession(stream, &signalWriteCloser{}), nil
+	}
+
+	session, err := stream.AppendSession(ctx, &AppendSessionOptions{RetryConfig: retryCfg})
+	if err != nil {
+		t.Fatalf("AppendSession: %v", err)
+	}
+	defer session.Close()
+
+	failed := newTransportSession(stream, &signalWriteCloser{})
+	session.sessionMu.Lock()
+	session.currentSession = failed
+	session.sessionMu.Unlock()
+
+	const callers = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	transportErr := errors.New("transport boom")
+
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			session.handleSessionError(failed, transportErr)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	session.stateMu.RLock()
+	got := session.currentAttempt
+	session.stateMu.RUnlock()
+	if got != 1 {
+		t.Fatalf("one logical failure should bump currentAttempt by 1, got %d after %d concurrent reports", got, callers)
+	}
+
+	session.sessionMu.RLock()
+	current := session.currentSession
+	session.sessionMu.RUnlock()
+	if current != nil {
+		t.Fatalf("expected currentSession cleared after claim, still %p", current)
 	}
 }


### PR DESCRIPTION
## Summary
- A single transport failure can be reported twice — once by the write path (`appendInput` error) and once by `readAcks` draining `session.errorsCh`. The old read-only `isCurrent` guard at the top of `handleSessionError` let both callers through; the entire handler ran twice, including double-incrementing `currentAttempt` and double-scheduling retries. With `MaxAttempts=3`, users got 2 retries instead of 3.
- This PR replaces the read-only check with an atomic claim: take `sessionMu`, verify `currentSession == failedSession`, swap to nil, release. The loser observes the swap and bails before logging, before noSideEffects checks, before the attempt increment, and before `scheduleRetry`. The middle "clear currentSession" block becomes redundant and is removed.
- Also collapses the split `RLock`-then-`Lock` around `currentAttempt` into a single `Lock`, so the `failedSession == nil` path (timeouts) is also race-free.

Closes #269

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./s2/...`
- [x] New regression test (`TestAppendSession_HandleSessionErrorIsIdempotentAcrossConcurrentCalls`) fires 8 goroutines into `handleSessionError` with the same failed session simultaneously and asserts `currentAttempt == 1` and `currentSession == nil`. Passed 20/20 under `-race`.
- [x] `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)