### PR TITLE
fix(append): make retryAt check-and-clear atomic to preserve backoff delay

### DIFF
--- a/s2/append_session.go
+++ b/s2/append_session.go
@@ -268,14 +268,18 @@ func (r *AppendSession) processInflightQueue() {
 	default:
 	}
 
-	r.stateMu.RLock()
-	retryAt := r.retryAt
-	r.stateMu.RUnlock()
-	if !retryAt.IsZero() && time.Now().Before(retryAt) {
-		return
-	}
+	// Check-and-clear retryAt atomically under a single exclusive lock. A
+	// separate read/clear sequence leaves a gap in which a concurrent
+	// scheduleRetry (driven by the readAcks goroutine) can set retryAt only
+	// to have it immediately overwritten here, bypassing the backoff delay.
 	r.stateMu.Lock()
-	r.retryAt = time.Time{}
+	if retryAt := r.retryAt; !retryAt.IsZero() {
+		if time.Now().Before(retryAt) {
+			r.stateMu.Unlock()
+			return
+		}
+		r.retryAt = time.Time{}
+	}
 	r.stateMu.Unlock()
 
 	r.inflightMu.RLock()


### PR DESCRIPTION
## Problem

Fixes #295.

`processInflightQueue` had a data race on `retryAt`:

1. It read `retryAt` under a **read** lock, then released it.
2. It checked the delay, then re-acquired a **write** lock to clear `retryAt = time.Time{}`.

The `readAcks` goroutine (spawned per session) calls `handleSessionError` → `scheduleRetry`, which sets `retryAt` under the write lock. If that landed in the gap between the pump's read-unlock and its write-lock-clear, the pump **clobbered the freshly-scheduled retry time** and proceeded straight to `getSession()` — reconnecting during the intended backoff window.

## Fix

Consolidate the check-and-clear into a single exclusive `stateMu.Lock()` section. `retryAt` is now read, time-compared, and cleared atomically, so a concurrent `scheduleRetry` either fully precedes (delay honored) or fully follows (its write preserved) — no lost write.

## Testing

- `go build ./...` and `go vet ./s2/` pass
- Append/retry/pump tests pass under `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)