### PR TITLE
docs: cover Ensure basin/stream and Locations API in test matrices

### DIFF
--- a/docs/test_basins_api.md
+++ b/docs/test_basins_api.md
@@ -32,6 +32,10 @@ This document enumerates every knob/parameter of the Basin API to ensure SDK tes
 - `DELETE /basins/{basin}` — `delete_basin` — Delete a basin
 - `PATCH /basins/{basin}` — `reconfigure_basin` — Reconfigure a basin
 
+### SDK-Specific Operations
+
+- `Ensure` — Idempotently create-or-converge a basin to a desired config. Wraps `PUT /basins/{basin}` and surfaces a `ProvisionResult` (`created` / `updated` / `noop`) derived from the response.
+
 ---
 
 ## 1. List Basins
@@ -744,6 +748,97 @@ This document enumerates every knob/parameter of the Basin API to ensure SDK tes
 
 - **Permission denied**
   - Setup: token without `reconfigure-basin` op
+  - Expected: 403 (`permission_denied`)
+
+---
+
+## 7. Ensure Basin (SDK)
+
+**SDK operation `Ensure` → `PUT /basins/{basin}`**
+
+An idempotent, SDK-level convenience that creates the basin if it does not
+exist, or converges its config to exactly match the requested configuration
+(after defaults are applied) if it does. Uses HTTP PUT semantics and is always
+safe to retry.
+
+### Arguments: EnsureBasinArgs
+
+- `basin` (BasinName, required)
+  - Basin name
+  - Constraints: 8-48 chars
+
+- `config` (BasinConfig, optional)
+  - Desired configuration for the basin
+  - If omitted, the basin is ensured with the default configuration
+
+- `location` (LocationName, optional)
+  - Basin location
+  - If omitted when creating, the service uses the account's default location
+  - Cannot be changed once the basin exists
+
+### Response: EnsureBasinResponse
+
+- `result` (ProvisionResult)
+  - `created` — basin was newly created
+  - `updated` — basin already existed and its config was changed to match
+  - `noop` — basin already existed and no write was needed
+
+- `basin` (BasinInfo)
+  - Current basin info
+
+### Response Codes
+
+- `200` — Basin already existed (mapped to `updated` or `noop`)
+- `201` — Basin newly created (mapped to `created`)
+- `400` — Bad request (`bad_json`)
+- `403` — Forbidden / limit exhausted (`permission_denied`, `quota_exhausted`)
+- `408` — Timeout (`request_timeout`)
+- `409` — Conflict (`basin_deletion_pending`, `transaction_conflict`)
+- `422` — Validation error / location mismatch (`invalid`)
+
+### Test Cases
+
+- **Ensure new basin (no config)**
+  - Input: new name, no config, no location
+  - Expected: `result == created`, basin created with default config
+
+- **Ensure new basin with config**
+  - Input: new name + config
+  - Expected: `result == created`, returned config matches requested (after defaults)
+
+- **Ensure existing basin with same config**
+  - Setup: basin already exists with matching config
+  - Input: same name + identical config
+  - Expected: `result == noop`, no write performed
+
+- **Ensure existing basin with changed config**
+  - Setup: basin exists with different config
+  - Input: same name + new config
+  - Expected: `result == updated`, config converged to requested
+
+- **Ensure is idempotent on repeat**
+  - Input: call Ensure twice with identical args
+  - Expected: first call `created` or `updated`, second call `noop`
+
+- **Ensure with location on create**
+  - Input: get a location from the Locations API, then ensure with that location
+  - Expected: `result == created`, basin placed in that location
+
+- **Ensure existing basin with different location**
+  - Setup: basin exists in location A
+  - Input: same name, location B
+  - Expected: 422 (`invalid`) — location cannot be changed
+
+- **Ensure with invalid basin name**
+  - Input: name outside 8-48 chars
+  - Expected: client-side validation error (no request sent)
+
+- **Ensure during basin deletion**
+  - Setup: delete basin, then Ensure
+  - Expected: 409 (`basin_deletion_pending`)
+
+- **Permission denied**
+  - Setup: token lacking the required op
   - Expected: 403 (`permission_denied`)
 
 ---

--- a/docs/test_locations_api.md
+++ b/docs/test_locations_api.md
@@ -90,16 +90,12 @@ explicit location.
 - `403` — Forbidden
   - Code: `permission_denied`
 
-- `404` — No default location set
-  - Code: `not_found`
-
 - `408` — Timeout
   - Code: `request_timeout`
 
 ### Test Cases
 
 - **Get default location**
-  - Setup: account with a default location
   - Input: none
   - Expected: 200, `LocationInfo` whose `name` appears in `List`
 
@@ -123,12 +119,17 @@ Sets the account's default location. Body is the `LocationName`.
 
 - `location` (LocationName, required)
   - Location name to set as the account default
+  - Constraints: 1-64 bytes
   - SDK rejects an empty string client-side (no request sent)
 
 ### Response Codes
 
 - `200` — Success
   - Body: `LocationInfo` reflecting the new default
+
+- `400` — Bad request
+  - Code: `bad_json`
+  - Cause: malformed request body
 
 - `403` — Forbidden
   - Code: `permission_denied`

--- a/docs/test_locations_api.md
+++ b/docs/test_locations_api.md
@@ -1,0 +1,174 @@
+# Locations API - SDK Test Matrix
+
+> **LLM Instructions**
+>
+> This document is a reference for generating SDK test code. Write tests based on the following instructions:
+>
+> - Write clean, concise, idiomatic code for the target language
+> - Do not add comments unless they explain non-obvious business logic
+> - Do not add TODO comments, redundant docstrings, or explanatory noise
+> - Each test should be self-contained and test exactly one behavior
+> - Use descriptive test names that document intent (no need for separate comments)
+> - Prefer table-driven/parameterized tests where appropriate
+> - Assert on specific expected values, not just "success"
+> - Show progress as each test progresses
+> - Set a timeout for each test
+> - The set of available locations is account- and service-dependent; assert on
+>   shape and invariants rather than hard-coding specific location names
+> - `SetDefault` mutates account-wide state; restore the prior default in cleanup
+>   when running against real backends
+
+---
+
+This document enumerates every knob/parameter of the Locations API to ensure SDK test coverage.
+
+Locations describe where basins can be placed. They are an account-level
+concept, accessed from the top-level client (not scoped to a basin).
+
+## Endpoints Overview
+
+- `GET /locations` — `list_locations` — List locations available to the account
+- `GET /locations/default` — `get_default_location` — Get the account's default location
+- `PUT /locations/default` — `set_default_location` — Set the account's default location
+
+---
+
+## 1. List Locations
+
+**`GET /locations`** — SDK `Locations.List`
+
+Lists the locations available to the account.
+
+### Response Codes
+
+- `200` — Success
+  - Body: array of `LocationInfo`
+
+- `403` — Forbidden
+  - Code: `permission_denied`
+  - Cause: token lacks the required permission
+
+- `408` — Timeout
+  - Code: `request_timeout`
+
+### Response Schema: LocationInfo
+
+- `name` (LocationName)
+  - Location name
+
+- `is_private` (boolean)
+  - `true` for account-private placements
+
+### Test Cases
+
+- **List available locations**
+  - Input: none
+  - Expected: 200, array of `LocationInfo`; each entry has a non-empty `name`
+
+- **Public and private flag present**
+  - Input: none
+  - Expected: each entry exposes an `is_private` boolean
+
+- **Permission denied**
+  - Setup: token lacking the required permission
+  - Expected: 403 (`permission_denied`)
+
+---
+
+## 2. Get Default Location
+
+**`GET /locations/default`** — SDK `Locations.GetDefault`
+
+Returns the account's default location, used when a basin is created without an
+explicit location.
+
+### Response Codes
+
+- `200` — Success
+  - Body: `LocationInfo`
+
+- `403` — Forbidden
+  - Code: `permission_denied`
+
+- `404` — No default location set
+  - Code: `not_found`
+
+- `408` — Timeout
+  - Code: `request_timeout`
+
+### Test Cases
+
+- **Get default location**
+  - Setup: account with a default location
+  - Input: none
+  - Expected: 200, `LocationInfo` whose `name` appears in `List`
+
+- **Default consistency with List**
+  - Input: call `GetDefault` then `List`
+  - Expected: the default's `name` is one of the listed locations
+
+- **Permission denied**
+  - Setup: token lacking the required permission
+  - Expected: 403 (`permission_denied`)
+
+---
+
+## 3. Set Default Location
+
+**`PUT /locations/default`** — SDK `Locations.SetDefault`
+
+Sets the account's default location. Body is the `LocationName`.
+
+### Arguments
+
+- `location` (LocationName, required)
+  - Location name to set as the account default
+  - SDK rejects an empty string client-side (no request sent)
+
+### Response Codes
+
+- `200` — Success
+  - Body: `LocationInfo` reflecting the new default
+
+- `403` — Forbidden
+  - Code: `permission_denied`
+
+- `408` — Timeout
+  - Code: `request_timeout`
+
+- `422` — Validation error
+  - Code: `invalid`
+  - Cause: unknown or non-selectable location
+
+### Test Cases
+
+- **Set default to a known location**
+  - Setup: pick a location returned by `List`
+  - Input: that location name
+  - Expected: 200, returned `LocationInfo.name` equals the requested name
+
+- **Set default then read back**
+  - Input: `SetDefault(loc)` followed by `GetDefault`
+  - Expected: `GetDefault` returns the same location
+
+- **Set default to empty string**
+  - Input: `""`
+  - Expected: client-side validation error (no request sent)
+
+- **Set default to unknown location**
+  - Input: a name not present in `List`
+  - Expected: 422 (`invalid`)
+
+- **Permission denied**
+  - Setup: token lacking the required permission
+  - Expected: 403 (`permission_denied`)
+
+---
+
+## Cross-API Notes
+
+- A basin's `location` (see Basin API) must be one of the locations exposed by
+  `List`. When a basin is created without a location, the service uses the value
+  from `GetDefault`.
+- A basin's location cannot be changed once the basin exists; changing the
+  account default via `SetDefault` does not relocate existing basins.

--- a/docs/test_streams_api.md
+++ b/docs/test_streams_api.md
@@ -1517,9 +1517,10 @@ PUT semantics and is always safe to retry.
 - `201` — Stream newly created (mapped to `created`)
 - `400` — Bad request (`bad_json`)
 - `403` — Forbidden (`permission_denied`)
+- `404` — Basin not found (`basin_not_found`)
 - `408` — Timeout (`request_timeout`)
-- `409` — Conflict (`transaction_conflict`)
-- `422` — Validation error (`invalid`)
+- `409` — Conflict (`stream_deletion_pending`, `transaction_conflict`)
+- `422` — Validation error / invalid config (`invalid`)
 
 ### Test Cases
 
@@ -1553,6 +1554,15 @@ PUT semantics and is always safe to retry.
 - **Ensure with invalid stream name**
   - Input: invalid stream name
   - Expected: client-side validation error (no request sent)
+
+- **Ensure stream in non-existent basin**
+  - Setup: client targeting a basin that does not exist
+  - Input: any stream name
+  - Expected: 404 (`basin_not_found`)
+
+- **Ensure with invalid config**
+  - Input: config with an invalid field (e.g. `retention_policy.age = 0`)
+  - Expected: 422 (`invalid`)
 
 - **Permission denied**
   - Setup: token lacking the required op

--- a/docs/test_streams_api.md
+++ b/docs/test_streams_api.md
@@ -143,6 +143,10 @@ This document enumerates every knob/parameter of the Stream API to ensure SDK te
 - `fence` — Set fencing token via command record
 - `trim` — Trim records via command record
 
+### SDK-Specific Operations
+
+- `Ensure` — Idempotently create-or-converge a stream to a desired config. Wraps `PUT /streams/{stream}` and surfaces a `ProvisionResult` (`created` / `updated` / `noop`) derived from the response. See section 12.
+
 > **Note:** SDKs may expose additional helper methods that wrap these operations. See section 10 (Command Records) and section 11 (SDK Client Lifecycle) for SDK-specific tests.
 
 ---
@@ -1475,6 +1479,84 @@ Test client initialization, configuration, and cleanup patterns exposed by the S
   - Expected: bodies and headers match original content in both formats
 
 > **Note:** Test all client/session creation patterns the SDK exposes (builders, factory methods, config objects, etc.)
+
+---
+
+## 12. Ensure Stream (SDK)
+
+**SDK operation `Ensure` → `PUT /streams/{stream}`**
+
+An idempotent, SDK-level convenience that creates the stream if it does not
+exist, or converges its config to exactly match the requested configuration if
+it does. Missing config fields are filled from the basin's default stream
+configuration and then global defaults before comparing or writing. Uses HTTP
+PUT semantics and is always safe to retry.
+
+### Arguments: EnsureStreamArgs
+
+- `stream` (StreamName, required)
+  - Stream name
+
+- `config` (StreamConfig, optional)
+  - Desired stream configuration before basin defaults are applied
+  - If omitted, the stream is ensured using basin and global defaults
+
+### Response: EnsureStreamResponse
+
+- `result` (ProvisionResult)
+  - `created` — stream was newly created
+  - `updated` — stream already existed and its config was changed to match
+  - `noop` — stream already existed and no write was needed
+
+- `stream` (StreamInfo)
+  - Current stream state
+
+### Response Codes
+
+- `200` — Stream already existed (mapped to `updated` or `noop`)
+- `201` — Stream newly created (mapped to `created`)
+- `400` — Bad request (`bad_json`)
+- `403` — Forbidden (`permission_denied`)
+- `408` — Timeout (`request_timeout`)
+- `409` — Conflict (`transaction_conflict`)
+- `422` — Validation error (`invalid`)
+
+### Test Cases
+
+- **Ensure new stream (no config)**
+  - Input: new name, no config
+  - Expected: `result == created`, stream created with basin/global defaults
+
+- **Ensure new stream with config**
+  - Input: new name + config
+  - Expected: `result == created`, returned config matches requested (after defaults)
+
+- **Ensure existing stream with same config**
+  - Setup: stream already exists with matching effective config
+  - Input: same name + identical config
+  - Expected: `result == noop`, no write performed
+
+- **Ensure existing stream with changed config**
+  - Setup: stream exists with different config
+  - Input: same name + new config
+  - Expected: `result == updated`, config converged to requested
+
+- **Ensure is idempotent on repeat**
+  - Input: call Ensure twice with identical args
+  - Expected: first call `created` or `updated`, second call `noop`
+
+- **Ensure partial config fills from basin defaults**
+  - Setup: basin has non-default default_stream_config
+  - Input: config with only some fields set
+  - Expected: omitted fields resolved from basin defaults before comparison
+
+- **Ensure with invalid stream name**
+  - Input: invalid stream name
+  - Expected: client-side validation error (no request sent)
+
+- **Permission denied**
+  - Setup: token lacking the required op
+  - Expected: 403 (`permission_denied`)
 
 ---
 


### PR DESCRIPTION
## What

Brings the `docs/` SDK test matrices in sync with the API on latest `main`. These matrices are the LLM reference used to generate SDK tests, and three newer API surfaces were missing:

- **Ensure Basin** — new `## 7. Ensure Basin (SDK)` section documenting the idempotent `BasinsClient.Ensure` (#297): `EnsureBasinArgs`/`EnsureBasinResponse`, the `ProvisionResult` (`created`/`updated`/`noop`) mapping over `PUT /basins/{basin}`, and test cases (create, noop, converge, idempotency, location-immutability, validation).
- **Ensure Stream** — matching `## 12. Ensure Stream (SDK)` section for `StreamsClient.Ensure` (#297), including basin-default fill-in behavior.
- **Locations API** — new `docs/test_locations_api.md` for `LocationsClient` (#302): `List`, `GetDefault`, `SetDefault`, plus cross-API notes tying basin `location` to the locations set.

## Note on "scope"

The remaining `scope` references in the access-token / metrics / core matrices refer to **access-token permission scope** (`AccessTokenScope`), which the `scope → location` refactor (#302) did **not** rename. Those are correct and left unchanged; the basin matrix was already updated to `location` by #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)