### PR TITLE
fix(bentobox): make batch AckFunc idempotent to prevent duplicate processing

### DIFF
--- a/s2-bentobox/stream_input.go
+++ b/s2-bentobox/stream_input.go
@@ -224,11 +224,27 @@ func (si *streamInput) handleBatch(_ context.Context, records []s2.SequencedReco
 
 	si.toAck.Add(records)
 
+	// Guard against multiple invocations: ack/nack side effects (cache writes,
+	// redelivery enqueues) must happen at most once per batch. A second call
+	// returns the cached result of the first instead of double-acking or
+	// re-enqueuing for redelivery, which would reprocess records.
+	//
+	// Bento calls the AckFunc "at least once" with no exactly-once guarantee,
+	// so the implementation must be idempotent. Mirrors the sync.Once used by
+	// Close.
+	var (
+		ackOnce   sync.Once
+		ackResult error
+	)
 	ackFunc := func(c context.Context, e error) error {
-		if e == nil {
-			return si.ack(c, records)
-		}
-		return si.nack(c, records)
+		ackOnce.Do(func() {
+			if e == nil {
+				ackResult = si.ack(c, records)
+			} else {
+				ackResult = si.nack(c, records)
+			}
+		})
+		return ackResult
 	}
 
 	return records, ackFunc, nil

--- a/s2-bentobox/stream_input_test.go
+++ b/s2-bentobox/stream_input_test.go
@@ -1,0 +1,83 @@
+package bentobox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	s2 "github.com/s2-streamstore/s2-sdk-go/s2"
+)
+
+func newTestStreamInput() *streamInput {
+	cache := newSeqNumCache(nil, silentLogger{})
+	return &streamInput{
+		Stream:   "demo",
+		cache:    cache,
+		toAck:    newToAckMap("demo", cache, silentLogger{}),
+		nacks:    make(chan []s2.SequencedRecord, 8),
+		Logger:   silentLogger{},
+		closedCh: make(chan struct{}),
+	}
+}
+
+// Calling the returned AckFunc more than once with an error must not enqueue
+// the same batch for redelivery more than once.
+func TestAckFuncDoubleNackEnqueuesOnce(t *testing.T) {
+	si := newTestStreamInput()
+	records := []s2.SequencedRecord{{SeqNum: 0}}
+
+	_, ackFunc, err := si.handleBatch(context.Background(), records)
+	if err != nil {
+		t.Fatalf("handleBatch: %v", err)
+	}
+
+	boom := errors.New("boom")
+	_ = ackFunc(context.Background(), boom)
+	_ = ackFunc(context.Background(), boom)
+
+	if got := len(si.nacks); got != 1 {
+		t.Fatalf("expected batch enqueued for redelivery exactly once, got %d", got)
+	}
+}
+
+// Once a batch is acked, a subsequent invocation with an error must not cause a
+// redelivery (which would reprocess already-committed records).
+func TestAckFuncAckThenNackDoesNotRedeliver(t *testing.T) {
+	si := newTestStreamInput()
+	records := []s2.SequencedRecord{{SeqNum: 0}}
+
+	_, ackFunc, err := si.handleBatch(context.Background(), records)
+	if err != nil {
+		t.Fatalf("handleBatch: %v", err)
+	}
+
+	if err := ackFunc(context.Background(), nil); err != nil {
+		t.Fatalf("first ack: %v", err)
+	}
+	_ = ackFunc(context.Background(), errors.New("boom"))
+
+	if got := len(si.nacks); got != 0 {
+		t.Fatalf("expected no redelivery after ack, got %d", got)
+	}
+}
+
+// Subsequent invocations must return the same result as the first.
+func TestAckFuncReturnsCachedResult(t *testing.T) {
+	si := newTestStreamInput()
+	records := []s2.SequencedRecord{{SeqNum: 0}}
+
+	_, ackFunc, err := si.handleBatch(context.Background(), records)
+	if err != nil {
+		t.Fatalf("handleBatch: %v", err)
+	}
+
+	first := ackFunc(context.Background(), nil)
+	second := ackFunc(context.Background(), nil)
+
+	if first != nil {
+		t.Fatalf("first ack returned error: %v", first)
+	}
+	if second != first {
+		t.Fatalf("expected cached result %v on repeat, got %v", first, second)
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #293.

The `AckFunc` returned by `streamInput.handleBatch` (via `ReadBatch`) invoked `ack`/`nack` with no guard against repeated calls:

```go
ackFunc := func(c context.Context, e error) error {
    if e == nil {
        return si.ack(c, records)
    }
    return si.nack(c, records)
}
```

Bento — which consumes this via the `BatchInput.ReadBatch(ctx) (MessageBatch, AckFunc, error)` shape — documents that the ack function is **"called for every message batch at least once, but there are no guarantees as to when this will occur"**, with no exactly-once or idempotency guarantee. So the framework can legitimately invoke the ack function more than once, and the implementation must tolerate it.

Without a guard, a second invocation could:
- **Double-nack / ack-then-nack** → re-enqueue an already-delivered batch onto the `nacks` channel, causing the same records to be redelivered and **reprocessed** (duplicate emails/charges/notifications, etc.).
- **Double-ack** → return a spurious `errCannotAckBatch` on the second call.

## Fix

Wrap the ack/nack body in a `sync.Once` that caches the first result and returns it on subsequent calls — mirroring the existing idempotency pattern used by `Close()` in the same file.

## Verification

Added regression tests that fail on the old code and pass on the new:

| Test | Old behavior | New behavior |
|---|---|---|
| `TestAckFuncDoubleNackEnqueuesOnce` | enqueued 2× | enqueued 1× |
| `TestAckFuncAckThenNackDoesNotRedeliver` | redelivered after commit | no redelivery |
| `TestAckFuncReturnsCachedResult` | spurious `errCannotAckBatch` | cached `nil` |

- `go build ./...` clean
- Full `s2-bentobox` suite passes under `go test -race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)