### PR TITLE
fix(bentobox): persist ack progress after stream close to prevent duplicates

### DIFF
--- a/s2-bentobox/stream_input.go
+++ b/s2-bentobox/stream_input.go
@@ -178,15 +178,6 @@ func connectStreamInput(
 	}, nil
 }
 
-func (si *streamInput) isClosed() bool {
-	select {
-	case <-si.closedCh:
-		return true
-	default:
-		return false
-	}
-}
-
 func (si *streamInput) ReadBatch(ctx context.Context) ([]s2.SequencedRecord, AckFunc, error) {
 	// Check for nacks first
 	select {
@@ -280,7 +271,13 @@ func (si *streamInput) ack(ctx context.Context, records []s2.SequencedRecord) er
 
 	si.Logger.With(withLog...).Debug("Acknowledging batch")
 
-	return si.toAck.MarkDone(ctx, records, !si.isClosed())
+	// Always persist acknowledged progress, even after the input is closed.
+	// Acks are dispatched to Bento asynchronously and routinely complete after
+	// the producing streamInput has been closed (session restart, stream
+	// removal, shutdown). Skipping the cache write on close silently loses that
+	// progress, so a reconnect or re-add resumes from a stale position and
+	// re-delivers already-acked records.
+	return si.toAck.MarkDone(ctx, records, true)
 }
 
 func (si *streamInput) Close(ctx context.Context) error {

--- a/s2-bentobox/stream_input_test.go
+++ b/s2-bentobox/stream_input_test.go
@@ -3,6 +3,7 @@ package bentobox
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	s2 "github.com/s2-streamstore/s2-sdk-go/s2"
@@ -79,5 +80,59 @@ func TestAckFuncReturnsCachedResult(t *testing.T) {
 	}
 	if second != first {
 		t.Fatalf("expected cached result %v on repeat, got %v", first, second)
+	}
+}
+
+// fakeCache is a durable SeqNumCache that records the last persisted value.
+type fakeCache struct {
+	mu     sync.Mutex
+	values map[string]uint64
+}
+
+func newFakeCache() *fakeCache { return &fakeCache{values: map[string]uint64{}} }
+
+func (f *fakeCache) Get(_ context.Context, stream string) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.values[stream], nil
+}
+
+func (f *fakeCache) Set(_ context.Context, stream string, seqNum uint64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[stream] = seqNum
+	return nil
+}
+
+// Reproduces issue #294: an ack that completes after the streamInput is closed
+// returns success but does not persist the sequence position, so a re-add of
+// the stream resumes from the stale position and re-delivers acked records.
+func TestAckAfterCloseDoesNotUpdateCache(t *testing.T) {
+	const stream = "demo"
+	inner := newFakeCache()
+	cache := newSeqNumCache(inner, silentLogger{})
+	si := &streamInput{
+		Stream:   stream,
+		cache:    cache,
+		toAck:    newToAckMap(stream, cache, silentLogger{}),
+		nacks:    make(chan []s2.SequencedRecord, 8),
+		Logger:   silentLogger{},
+		closedCh: make(chan struct{}),
+	}
+
+	records := []s2.SequencedRecord{{SeqNum: 100}, {SeqNum: 101}, {SeqNum: 102}}
+	si.toAck.Add(records)
+
+	// Simulate the streamInput having been closed (session restart / removal /
+	// shutdown) while this batch's ack is still pending in the Bento pipeline.
+	close(si.closedCh)
+
+	if err := si.ack(context.Background(), records); err != nil {
+		t.Fatalf("ack returned error: %v", err)
+	}
+
+	got, _ := inner.Get(context.Background(), stream)
+	if got != 103 {
+		t.Fatalf("expected durable cache to advance to 103 after ack, got %d", got)
 	}
 }


### PR DESCRIPTION
## Problem

Fixes #294.

`streamInput.ack` gated the cache update on the input not being closed:

```go
return si.toAck.MarkDone(ctx, records, !si.isClosed())
```

When the input is closed, `!si.isClosed()` is `false`, so `MarkDone` skips persisting the acknowledged sequence position — but `ack` still returns `nil`, so the caller believes the ack was durably recorded.

This is **not** an edge case. Acks flow to Bento asynchronously: `streamSourceRecvLoop` pushes each batch + `AckFunc` onto a buffered channel and the input is `Close`d (via `defer input.Close(ctx)`) on every **session restart** (`ErrInputClosed`), **stream removal**, and **shutdown**. In-flight acks therefore routinely complete *after* the producing `streamInput` is closed, and each one silently drops its cache update. On reconnect / re-add, `connectStreamInput` reads the stale cached position and **re-delivers already-acked records as duplicates** (for `MultiStreamInput`, removal also `Forget`s the in-memory entry, so the re-add reads the stale durable value).

## Fix

Always persist acknowledged progress: `MarkDone(ctx, records, true)`. Removes the now-unused `isClosed()` helper (it was its only caller).

## Verification

Added `TestAckAfterCloseDoesNotUpdateCache`, which closes the input before acking records 100–102 and asserts the durable cache advances to 103. Fails on old code (`got 0`), passes on new.

- `go build ./...` and `go vet ./s2-bentobox/` clean
- Full `s2-bentobox` suite passes under `go test -race`

## Note

Because reconnect reads the cached position while old acks may still be pending, an old session's late ack and a new session's early ack can momentarily write a lower position. This is bounded and convergent, and strictly better than today's permanently-stale behavior — it is inherent to the restart-with-pending-acks design. A blanket "monotonic cache" guard is **not** appropriate because the 416 path in `streamSourceRecvLoop` deliberately resets the cached position backward to the stream tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)