### PR TITLE
chore: add specsync skill; fix list args docs

### DIFF
--- a/.claude/skills/specsync/SKILL.md
+++ b/.claude/skills/specsync/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: specsync
+description: Sync the hand-written doc comments in s2/types.go with the s2-specs OpenAPI spec. Use after bumping the s2-specs submodule, or when asked to "sync types with the spec", "update type docs", or "check types.go against the spec".
+---
+
+# /specsync
+
+Keep `s2/types.go` in sync with the OpenAPI spec in the `s2-specs` submodule.
+
+The types are hand-written on purpose — curated field order, reshaped unions, branded
+scalars, and SDK-specific ergonomics that no generator should flatten. The thing that
+silently rots is the **doc comments**, which are copied from the spec by hand. This skill
+reconciles those docs (and catches structural drift) without regenerating the file.
+
+## Sources of truth
+
+- Spec: `s2-specs/s2/v1/openapi.json`
+  - `components.schemas.<Name>` — the data types (fields, enums, descriptions).
+  - `paths.<path>.<method>.parameters[]` — query parameters for list/metrics operations.
+- Code: `s2/types.go`
+
+## What to do vs. what to flag
+
+**Inject (edit the file):** doc-comment text that has drifted from the spec, where the
+spec wording is the intended source. This is the main job.
+
+**Flag for the human (do NOT auto-edit), then ask:** structural drift — a spec field with
+no Go field, a Go field whose JSON tag is no longer in the spec, an enum value added or
+removed, or a Go type that changed. Choosing the Go type, pointer-ness, and field order is
+a judgment call; surface it, don't guess.
+
+## How things map
+
+- **Schema → Go type:** same name, except the branded scalar renames:
+  `AccessTokenIdStr→AccessTokenID`, `BasinNameStr→BasinName`, `StreamNameStr→StreamName`.
+- **Property → Go field:** match by the `json:"..."` tag (strip `,omitempty`), not the field
+  name. `id`→`ID`, `seq_num`→`SeqNum`, etc.
+- **Query param → Go field:** list/metrics operations map to `…Args` structs. Match each
+  `in: query` parameter to the field by its JSON tag:
+  - `list_streams` → `ListStreamsArgs`
+  - `list_basins` → `ListBasinsArgs`
+  - `list_access_tokens` → `ListAccessTokensArgs`
+- **Doc comparison:** ignore line-wrapping. Go reflows comments across multiple `//` lines;
+  compare the collapsed text, only treat a real wording change as drift.
+
+## Intentional divergences — preserve these, do not "fix" them
+
+These are deliberate. If the only difference is one of these, leave the Go doc alone:
+
+- **`time.Time` fields drop "in RFC 3339 format".** The spec says e.g. "Creation time in RFC
+  3339 format."; the SDK uses `time.Time`, so the Go doc is just "Creation time." Keep it.
+- **`*bool` config fields.** `BasinConfig.CreateStreamOnAppend`/`CreateStreamOnRead` are
+  `*bool` though the spec marks them plain `boolean` — pointer distinguishes unset from false.
+- **Extra SDK guidance.** `StartAfter` docs carry "It must be greater than or equal to the
+  `prefix` if specified." which the spec omits. Keep it.
+- **Reshaped / hand-owned types — skip entirely:** `Metric` (spec `oneOf` → flat struct),
+  `Header` (spec `[2]string` → struct), `SequencedRecord`/`AppendRecord`/`AppendInput`
+  (binary `[]byte` bodies), `GaugeMetric`/`AccumulationMetric` tuple values, the four
+  `*Reconfiguration` types (Clear* fields + custom MarshalJSON), and all `…Args`/`…Options`/
+  `…Response` types that have no schema. Their docs are SDK-authored, not spec-derived.
+
+When in doubt whether a divergence is intentional, ask rather than overwrite.
+
+## Steps
+
+1. **Update the spec if asked.** Bump the submodule and confirm what changed:
+   ```bash
+   git -C s2-specs fetch origin --quiet && git -C s2-specs checkout main --quiet && git -C s2-specs pull --quiet
+   git diff --submodule=log s2-specs
+   ```
+   Proto is only regenerated when `s2-specs/s2/v1/s2.proto` changes (`task gen`); an
+   `openapi.json`-only change leaves `generated/` untouched.
+
+2. **Diff docs.** For each non-excluded schema, pull `description` for every property
+   (prefer the property description, then a `oneOf` branch description). Do the same for the
+   mapped query parameters. Compare against the matching Go field's doc comment, ignoring
+   wrapping.
+
+3. **Inject the spec wording** for every genuine doc drift that isn't an intentional
+   divergence above. Edit the `//` comment lines in `s2/types.go`; keep the existing field
+   order, types, and tags. Re-wrap long comments to match the surrounding style.
+
+4. **Flag structural drift** (missing/extra fields, type or enum changes) in your summary
+   and ask how to handle it — don't edit struct fields yourself.
+
+5. **Verify:**
+   ```bash
+   gofmt -l s2/types.go    # must print nothing
+   go build ./... && go test ./s2/ -count=1
+   ```
+
+6. **Report:** list the docs you changed, the intentional divergences you left, and any
+   structural drift that needs a decision.

--- a/.claude/skills/specsync/SKILL.md
+++ b/.claude/skills/specsync/SKILL.md
@@ -7,87 +7,90 @@ description: Sync the hand-written doc comments in s2/types.go with the s2-specs
 
 Keep `s2/types.go` in sync with the OpenAPI spec in the `s2-specs` submodule.
 
-The types are hand-written on purpose — curated field order, reshaped unions, branded
-scalars, and SDK-specific ergonomics that no generator should flatten. The thing that
-silently rots is the **doc comments**, which are copied from the spec by hand. This skill
-reconciles those docs (and catches structural drift) without regenerating the file.
+The types are hand-written on purpose: curated field order, reshaped unions, branded
+scalars, and SDK-specific ergonomics that no generator should flatten. The doc comments are
+copied from the spec by hand, so they go stale when the spec changes. This skill updates
+those doc comments and reports structural drift. It does not regenerate the file.
 
 ## Sources of truth
 
 - Spec: `s2-specs/s2/v1/openapi.json`
-  - `components.schemas.<Name>` — the data types (fields, enums, descriptions).
-  - `paths.<path>.<method>.parameters[]` — query parameters for list/metrics operations.
+  - `components.schemas.<Name>`: the data types (fields, enums, descriptions).
+  - `paths.<path>.<method>.parameters[]`: query parameters for list and metrics operations.
 - Code: `s2/types.go`
 
-## What to do vs. what to flag
+## What to edit vs. what to flag
 
-**Inject (edit the file):** doc-comment text that has drifted from the spec, where the
-spec wording is the intended source. This is the main job.
+Edit the file for doc-comment text that has drifted from the spec, where the spec wording
+is the intended source. That is the main job.
 
-**Flag for the human (do NOT auto-edit), then ask:** structural drift — a spec field with
-no Go field, a Go field whose JSON tag is no longer in the spec, an enum value added or
-removed, or a Go type that changed. Choosing the Go type, pointer-ness, and field order is
-a judgment call; surface it, don't guess.
+Flag for the human (do not edit), then ask, for structural drift: a spec field with no Go
+field, a Go field whose JSON tag is no longer in the spec, an enum value added or removed,
+or a Go type that changed. The Go type, pointer-ness, and field order are judgment calls.
+Report them, do not guess.
 
 ## How things map
 
-- **Schema → Go type:** same name, except the branded scalar renames:
-  `AccessTokenIdStr→AccessTokenID`, `BasinNameStr→BasinName`, `StreamNameStr→StreamName`.
-- **Property → Go field:** match by the `json:"..."` tag (strip `,omitempty`), not the field
-  name. `id`→`ID`, `seq_num`→`SeqNum`, etc.
-- **Query param → Go field:** list/metrics operations map to `…Args` structs. Match each
+- Schema to Go type: same name, except the branded scalar renames:
+  `AccessTokenIdStr` to `AccessTokenID`, `BasinNameStr` to `BasinName`, `StreamNameStr` to
+  `StreamName`.
+- Property to Go field: match by the `json:"..."` tag (strip `,omitempty`), not the field
+  name. `id` becomes `ID`, `seq_num` becomes `SeqNum`, and so on.
+- Query param to Go field: list and metrics operations map to `…Args` structs. Match each
   `in: query` parameter to the field by its JSON tag:
-  - `list_streams` → `ListStreamsArgs`
-  - `list_basins` → `ListBasinsArgs`
-  - `list_access_tokens` → `ListAccessTokensArgs`
-- **Doc comparison:** ignore line-wrapping. Go reflows comments across multiple `//` lines;
-  compare the collapsed text, only treat a real wording change as drift.
+  - `list_streams` to `ListStreamsArgs`
+  - `list_basins` to `ListBasinsArgs`
+  - `list_access_tokens` to `ListAccessTokensArgs`
+- Doc comparison: ignore line-wrapping. Go reflows comments across multiple `//` lines.
+  Compare the collapsed text, and only treat a real wording change as drift.
 
-## Intentional divergences — preserve these, do not "fix" them
+## Intentional divergences: keep these, do not change them
 
-These are deliberate. If the only difference is one of these, leave the Go doc alone:
+These are deliberate. If the only difference is one of the following, leave the Go doc as is:
 
-- **`time.Time` fields drop "in RFC 3339 format".** The spec says e.g. "Creation time in RFC
-  3339 format."; the SDK uses `time.Time`, so the Go doc is just "Creation time." Keep it.
-- **`*bool` config fields.** `BasinConfig.CreateStreamOnAppend`/`CreateStreamOnRead` are
-  `*bool` though the spec marks them plain `boolean` — pointer distinguishes unset from false.
-- **Extra SDK guidance.** `StartAfter` docs carry "It must be greater than or equal to the
-  `prefix` if specified." which the spec omits. Keep it.
-- **Reshaped / hand-owned types — skip entirely:** `Metric` (spec `oneOf` → flat struct),
-  `Header` (spec `[2]string` → struct), `SequencedRecord`/`AppendRecord`/`AppendInput`
-  (binary `[]byte` bodies), `GaugeMetric`/`AccumulationMetric` tuple values, the four
-  `*Reconfiguration` types (Clear* fields + custom MarshalJSON), and all `…Args`/`…Options`/
-  `…Response` types that have no schema. Their docs are SDK-authored, not spec-derived.
+- `time.Time` fields drop "in RFC 3339 format". The spec says e.g. "Creation time in RFC
+  3339 format.". The SDK uses `time.Time`, so the Go doc is just "Creation time.".
+- `*bool` config fields. `BasinConfig.CreateStreamOnAppend` and `CreateStreamOnRead` are
+  `*bool` though the spec marks them plain `boolean`. The pointer distinguishes unset from
+  false.
+- Extra SDK guidance. `StartAfter` docs carry "It must be greater than or equal to the
+  `prefix` if specified.", which the spec omits.
+- Reshaped or hand-owned types, skip entirely: `Metric` (spec `oneOf`, modeled as a flat
+  struct), `Header` (spec `[2]string`, modeled as a struct), `SequencedRecord`,
+  `AppendRecord`, `AppendInput` (binary `[]byte` bodies), `GaugeMetric` and
+  `AccumulationMetric` tuple values, the four `*Reconfiguration` types (Clear* fields plus
+  custom MarshalJSON), and all `…Args`, `…Options`, and `…Response` types that have no
+  schema. Their docs are SDK-authored, not spec-derived.
 
-When in doubt whether a divergence is intentional, ask rather than overwrite.
+If you are unsure whether a divergence is intentional, ask before changing it.
 
 ## Steps
 
-1. **Update the spec if asked.** Bump the submodule and confirm what changed:
+1. Update the spec if asked. Bump the submodule and confirm what changed:
    ```bash
    git -C s2-specs fetch origin --quiet && git -C s2-specs checkout main --quiet && git -C s2-specs pull --quiet
    git diff --submodule=log s2-specs
    ```
-   Proto is only regenerated when `s2-specs/s2/v1/s2.proto` changes (`task gen`); an
+   Proto is only regenerated when `s2-specs/s2/v1/s2.proto` changes (`task gen`). An
    `openapi.json`-only change leaves `generated/` untouched.
 
-2. **Diff docs.** For each non-excluded schema, pull `description` for every property
+2. Diff docs. For each non-excluded schema, read the `description` for every property
    (prefer the property description, then a `oneOf` branch description). Do the same for the
    mapped query parameters. Compare against the matching Go field's doc comment, ignoring
    wrapping.
 
-3. **Inject the spec wording** for every genuine doc drift that isn't an intentional
-   divergence above. Edit the `//` comment lines in `s2/types.go`; keep the existing field
+3. Inject the spec wording for every genuine doc drift that is not one of the intentional
+   divergences above. Edit the `//` comment lines in `s2/types.go`. Keep the existing field
    order, types, and tags. Re-wrap long comments to match the surrounding style.
 
-4. **Flag structural drift** (missing/extra fields, type or enum changes) in your summary
-   and ask how to handle it — don't edit struct fields yourself.
+4. Flag structural drift (missing or extra fields, type or enum changes) in your summary and
+   ask how to handle it. Do not edit struct fields yourself.
 
-5. **Verify:**
+5. Verify:
    ```bash
    gofmt -l s2/types.go    # must print nothing
    go build ./... && go test ./s2/ -count=1
    ```
 
-6. **Report:** list the docs you changed, the intentional divergences you left, and any
+6. Report: list the docs you changed, the intentional divergences you left, and any
    structural drift that needs a decision.

--- a/s2/types.go
+++ b/s2/types.go
@@ -212,12 +212,13 @@ type BasinConfig struct {
 }
 
 type StreamInfo struct {
+	// Stream name.
 	Name StreamName `json:"name"`
 	// Creation time.
 	CreatedAt time.Time `json:"created_at"`
 	// Deletion time, if the stream is being deleted.
 	DeletedAt *time.Time `json:"deleted_at,omitempty"`
-	// Encryption algorithm for the stream, if encryption is enabled.
+	// Encryption algorithm for this stream, if encryption is enabled.
 	Cipher *EncryptionAlgorithm `json:"cipher,omitempty"`
 }
 

--- a/s2/types.go
+++ b/s2/types.go
@@ -613,9 +613,9 @@ type AppendSessionOptions struct {
 }
 
 type ListAccessTokensArgs struct {
-	// Filter to access tokens whose ID begins with this prefix.
+	// Filter to access tokens whose IDs begin with this prefix.
 	Prefix string `json:"prefix,omitempty"`
-	// Filter to access tokens whose ID lexicographically starts after this string.
+	// Filter to access tokens whose IDs lexicographically start after this string.
 	StartAfter string `json:"start_after,omitempty"`
 	// Number of results, up to a maximum of 1000.
 	Limit *int `json:"limit,omitempty"`
@@ -694,9 +694,9 @@ type EnsureBasinResponse struct {
 }
 
 type ListStreamsArgs struct {
-	// Filter to streams whose name begins with this prefix.
+	// Filter to streams whose names begin with this prefix.
 	Prefix string `json:"prefix,omitempty"`
-	// Filter to streams whose name begins with this prefix.
+	// Filter to streams whose names lexicographically start after this string.
 	// It must be greater than or equal to the `prefix` if specified.
 	StartAfter string `json:"start_after,omitempty"`
 	// Number of results, up to a maximum of 1000.


### PR DESCRIPTION
## What

Adds a **`specsync` skill** that keeps the hand-written `s2/types.go` doc comments in sync with the OpenAPI spec, and fixes the drift it surfaced.

The types are hand-written on purpose (curated field order, reshaped unions, branded scalars). What rots is the doc comments, copied from the spec by hand. The skill reconciles those: it diffs `s2/types.go` against `s2-specs/s2/v1/openapi.json` — both `components.schemas` fields and `paths.*` query params (→ `…Args` structs) — injects updated spec wording for stale docs, and flags structural drift for review rather than guessing.

It encodes the mapping rules (scalar renames, json-tag matching) and the **intentional divergences to preserve**: `time.Time` fields dropping "in RFC 3339 format", `*bool` config fields, extra SDK guidance, and the reshaped/SDK-only types.

Invoke with `/specsync`.

> Replaces an earlier Go-tool version of this — a compiled checker was more machinery than the job needs.

## Fix surfaced while building it

- **`ListStreamsArgs.StartAfter`** documented a *prefix* filter (copy-pasted from `Prefix`) instead of lexicographic start-after semantics. Corrected, along with the related `prefix`/`start_after` docs on `ListStreamsArgs` and `ListAccessTokensArgs`.

## Spec bump

- Updates the `s2-specs` submodule to latest (adds the Locations API; aligns `BasinInfo` to `location`). Proto sources unchanged, so `generated/` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)