### PR TITLE
fix(docs): correct ReadSession.Next() usage in package docs

### DIFF
--- a/s2/readme.go
+++ b/s2/readme.go
@@ -48,7 +48,7 @@ Generate an authentication token by logging onto the web console at s2.dev.
 		}
 		defer session.Close()
 
-		for session.Next(ctx) {
+		for session.Next() {
 			rec := session.Record()
 			fmt.Printf("[%d] %s\n", rec.SeqNum, string(rec.Body))
 		}
@@ -84,7 +84,7 @@ Read session
 	}
 	defer session.Close()
 
-	for session.Next(ctx) {
+	for session.Next() {
 		rec := session.Record()
 		// process rec
 	}


### PR DESCRIPTION
## What

`s2/readme.go` documented `for session.Next(ctx) { ... }` in the Quick Start and Read Session examples, but `ReadSession.Next()` takes no arguments. Copying the docs produced a compile error (`too many arguments in call to s2.ReadSession.Next`) and misrepresented the API: the context is passed to `stream.ReadSession(ctx, ...)`, not to `Next()`.

Corrected both occurrences to `for session.Next()`.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)