### PR TITLE
fix(http): surface error-response body read failures as network errors

### DIFF
--- a/s2/append.go
+++ b/s2/append.go
@@ -160,9 +160,14 @@ func (p *transportAppendSession) connectAndRead(req *http.Request, pipeWriter *i
 	}
 
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		resp.Body.Close()
-		apiErr := decodeAPIError(resp.StatusCode, body)
+		var apiErr error
+		if readErr != nil {
+			apiErr = newBodyReadError(resp.StatusCode, body, readErr)
+		} else {
+			apiErr = decodeAPIError(resp.StatusCode, body)
+		}
 		pipeWriter.CloseWithError(apiErr)
 		p.reportError(apiErr)
 		return

--- a/s2/error.go
+++ b/s2/error.go
@@ -222,7 +222,7 @@ func decodeAPIError(status int, body []byte) error {
 // Without this, a body read that fails mid-stream would feed partial bytes to
 // decodeAPIError and surface as a misleading server error.
 func newBodyReadError(status int, partial []byte, err error) *S2Error {
-	message := fmt.Sprintf("failed to read error response body (HTTP %d): %s", status, err)
+	message := fmt.Sprintf("failed to read error response body: %s", err)
 	if trimmed := bytes.TrimSpace(partial); len(trimmed) > 0 {
 		message = fmt.Sprintf("%s (partial body: %q)", message, trimmed)
 	}

--- a/s2/error.go
+++ b/s2/error.go
@@ -216,6 +216,23 @@ func decodeAPIError(status int, body []byte) error {
 	}
 }
 
+// newBodyReadError reports a failure to read an HTTP error-response body. The
+// HTTP status is preserved, but Origin is "network" because the body read (not
+// the server) is what failed; any partial body is included for diagnostics.
+// Without this, a body read that fails mid-stream would feed partial bytes to
+// decodeAPIError and surface as a misleading server error.
+func newBodyReadError(status int, partial []byte, err error) *S2Error {
+	message := fmt.Sprintf("failed to read error response body (HTTP %d): %s", status, err)
+	if trimmed := bytes.TrimSpace(partial); len(trimmed) > 0 {
+		message = fmt.Sprintf("%s (partial body: %q)", message, trimmed)
+	}
+	return &S2Error{
+		Message: message,
+		Status:  status,
+		Origin:  "network",
+	}
+}
+
 func makeStreamResetError(err error, context string) error {
 	var message string
 	if err != nil {

--- a/s2/http.go
+++ b/s2/http.go
@@ -87,7 +87,12 @@ func (h *httpClient) requestWithHeadersResult(ctx context.Context, method, path 
 	logInfo(h.logger, "s2 http response", "method", method, "path", path, "status", resp.StatusCode)
 
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		if readErr != nil {
+			bodyErr := newBodyReadError(resp.StatusCode, body, readErr)
+			logError(h.logger, "s2 http error response body read failed", "method", method, "path", path, "status", resp.StatusCode, "error", readErr)
+			return nil, bodyErr
+		}
 		apiErr := decodeAPIError(resp.StatusCode, body)
 		logError(h.logger, "s2 http error response", "method", method, "path", path, "status", resp.StatusCode, "message", apiErr.Error())
 		return nil, apiErr
@@ -185,7 +190,12 @@ func (h *httpClient) requestProto(
 	logInfo(h.logger, "s2 http proto response", "method", method, "path", path, "status", resp.StatusCode)
 
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		if readErr != nil {
+			bodyErr := newBodyReadError(resp.StatusCode, body, readErr)
+			logError(h.logger, "s2 http proto error response body read failed", "method", method, "path", path, "status", resp.StatusCode, "error", readErr)
+			return bodyErr
+		}
 		if encoding := resp.Header.Get("Content-Encoding"); encoding != "" {
 			respCompression := internalframing.ParseContentEncoding(encoding)
 			decompressed, err := internalframing.Decompress(body, respCompression)

--- a/s2/stream.go
+++ b/s2/stream.go
@@ -97,7 +97,10 @@ func (s *StreamClient) CheckTail(ctx context.Context) (*TailResponse, error) {
 func parseHTTPError(resp *http.Response) error {
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+	if readErr != nil {
+		return newBodyReadError(resp.StatusCode, body, readErr)
+	}
 	return decodeAPIError(resp.StatusCode, body)
 }
 


### PR DESCRIPTION
## What

The HTTP error-response paths discarded the `io.ReadAll` error:

```go
body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
apiErr := decodeAPIError(resp.StatusCode, body)
```

When a body read fails mid-stream (e.g. connection reset), Go returns partial bytes **plus** a non-nil error. Discarding it meant those partial bytes were passed to `decodeAPIError`, which falls back to `S2Error{Message: string(body), Origin: "server"}` — reporting corrupted/truncated JSON as an authoritative server error and masking the real network failure. The success path already treats the same read error as fatal, so the error path was inconsistent.

## Fix

- Added `newBodyReadError(status, partial, err)` in `s2/error.go`: an `*S2Error` with `Origin: "network"`, the preserved HTTP status, a clear message, and any partial body for diagnostics.
- Check the read error in all four error paths: `requestJSON` (`http.go`), `requestProto` (`http.go`), `parseHTTPError` (`stream.go`), and the append-session connect path (`append.go`).

`io.LimitReader` truncation does not produce an error, so normal size-capping is unaffected; only genuine read failures are caught. `append.go`'s frame-based `decodeAPIError` call reads from `frame.DecompressedBody()` (which already handles its error) and is out of scope.

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)