### PR TITLE
fix(metrics): limit error response body reads to 64 KiB (#313)

### DIFF
--- a/s2/metrics.go
+++ b/s2/metrics.go
@@ -147,13 +147,17 @@ func (m *MetricsClient) fetchMetrics(ctx context.Context, endpoint string, set s
 		}
 		defer resp.Body.Close()
 
+		if resp.StatusCode >= 400 {
+			body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+			if readErr != nil {
+				return nil, newBodyReadError(resp.StatusCode, body, readErr)
+			}
+			return nil, decodeAPIError(resp.StatusCode, body)
+		}
+
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("reading response: %w", err)
-		}
-
-		if resp.StatusCode >= 400 {
-			return nil, decodeAPIError(resp.StatusCode, body)
 		}
 
 		var result MetricSetResponse


### PR DESCRIPTION
## Summary
Fixes #313.

`MetricsClient.fetchMetrics` read the entire response body unconditionally before checking the status code, so HTTP error bodies (status >= 400) were read without the SDK's standard 64 KiB cap (`maxErrorBodyBytes`) that's applied on every other error path (`s2/http.go`, `s2/stream.go`, `s2/append.go`).

## Change
- Check `resp.StatusCode` **before** reading the body.
- On the error path, wrap the reader with `io.LimitReader(resp.Body, maxErrorBodyBytes)`.
- Surface read failures via `newBodyReadError`, matching the other paths.
- The success path is unchanged (reads the full body for JSON decoding).

## Notes
This is a defense-in-depth / consistency fix, not a critical vulnerability. No unit test added: this repo's `s2` tests are integration tests against a live server, and the parallel `LimitReader` paths have no unit coverage either — adding an httptest harness here would be a one-off divergence from the existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)