### PR TITLE
fix(bentobox): correct SeqNumCache miss contract (#311)

### DIFF
--- a/s2-bentobox/input.go
+++ b/s2-bentobox/input.go
@@ -21,10 +21,19 @@ type (
 
 // SeqNumCache is used to persist read progress across restarts.
 //
-// Get must return (0, nil) when no entry exists for the given stream (cache
-// miss). Returning a non-nil error for a miss (e.g. redis.Nil, sql.ErrNoRows)
-// is treated as a cache failure: the error is logged as a warning and the
-// consumer falls back to the configured InputStartSeqNum default.
+// Get must return a non-nil error when no entry exists for the given stream
+// (a cache miss). Returning ErrNoCacheEntry is the idiomatic way to signal a
+// miss, but any non-nil error is treated the same: the consumer falls back to
+// the configured InputStartSeqNum default (so InputStartSeqNumLatest tails from
+// the end). Errors that are not ErrNoCacheEntry are also logged as a warning,
+// since they may indicate a transient backend failure rather than a clean miss
+// (e.g. redis.Nil and sql.ErrNoRows naturally surface as errors and can be
+// returned as-is).
+//
+// Do NOT return (0, nil) for a miss: the interface cannot distinguish that from
+// a real cached position of 0, so it is interpreted as "resume from sequence
+// number 0" and causes InputStartSeqNumLatest to replay from the beginning
+// instead of tailing.
 //
 // Set must durably store the next sequence number to consume for the stream.
 type SeqNumCache interface {
@@ -59,11 +68,14 @@ func (s *seqNumCache) Get(ctx context.Context, stream string) (uint64, error) {
 
 	cached, err := s.inner.Get(ctx, stream)
 	if err != nil {
-		// The SeqNumCache interface cannot distinguish between a cache miss and
-		// a transient error. Log the error so it is visible, then treat it as
-		// no entry so the caller falls back to the configured default start
-		// position rather than blocking indefinitely.
-		s.logger.With("stream", stream, "error", err).Warn("Cache lookup failed, starting from default position")
+		// Any error from the inner cache is treated as no entry so the caller
+		// falls back to the configured default start position rather than
+		// blocking indefinitely. ErrNoCacheEntry is the idiomatic miss signal,
+		// so only log when the error is something else: it may indicate a
+		// transient backend failure rather than a clean miss.
+		if !errors.Is(err, ErrNoCacheEntry) {
+			s.logger.With("stream", stream, "error", err).Warn("Cache lookup failed, starting from default position")
+		}
 		return 0, ErrNoCacheEntry
 	}
 

--- a/s2-bentobox/multi_stream_input_test.go
+++ b/s2-bentobox/multi_stream_input_test.go
@@ -292,3 +292,51 @@ func TestStreamSourceRecvLoopForgetsStaleMemEntryWhenSetFails(t *testing.T) {
 		t.Fatal("expected in-memory cache entry to be cleared after failed Set")
 	}
 }
+
+type erroringCache struct {
+	err error
+}
+
+func (c *erroringCache) Get(context.Context, string) (uint64, error) { return 0, c.err }
+func (c *erroringCache) Set(context.Context, string, uint64) error   { return nil }
+
+type warnCountingLogger struct {
+	silentLogger
+	warns *int
+}
+
+func (l warnCountingLogger) With(...any) Logger { return l }
+func (l warnCountingLogger) Warn(string)        { *l.warns++ }
+func (l warnCountingLogger) Warnf(string, ...any) {
+	*l.warns++
+}
+
+// A clean miss signalled via ErrNoCacheEntry must surface as ErrNoCacheEntry
+// without being logged as a failure; any other error is also surfaced as
+// ErrNoCacheEntry but logged as a warning since it may be a transient backend
+// fault rather than a real miss.
+func TestSeqNumCacheGetMissLogging(t *testing.T) {
+	t.Run("ErrNoCacheEntry does not warn", func(t *testing.T) {
+		var warns int
+		cache := newSeqNumCache(&erroringCache{err: ErrNoCacheEntry}, warnCountingLogger{warns: &warns})
+
+		if _, err := cache.Get(context.Background(), "s"); !errors.Is(err, ErrNoCacheEntry) {
+			t.Fatalf("expected ErrNoCacheEntry, got %v", err)
+		}
+		if warns != 0 {
+			t.Fatalf("clean miss should not warn; got %d warnings", warns)
+		}
+	})
+
+	t.Run("other error warns", func(t *testing.T) {
+		var warns int
+		cache := newSeqNumCache(&erroringCache{err: errors.New("backend down")}, warnCountingLogger{warns: &warns})
+
+		if _, err := cache.Get(context.Background(), "s"); !errors.Is(err, ErrNoCacheEntry) {
+			t.Fatalf("expected ErrNoCacheEntry, got %v", err)
+		}
+		if warns != 1 {
+			t.Fatalf("backend error should warn once; got %d warnings", warns)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Fixes #311.

`SeqNumCache.Get`'s doc told custom cache implementers to return `(0, nil)` on a cache miss, but the interface **cannot distinguish that from a real cached position of 0**. The consumer only falls back to the configured start position when `Get` returns an error (`ErrNoCacheEntry`):

```go
startSeqNum, err := cache.Get(ctx, stream)
if errors.Is(err, ErrNoCacheEntry) {
    if inputStartSeqNum == InputStartSeqNumLatest {
        opts.TailOffset = s2.Int64(0)   // tail from end
    } ...
} else {
    opts.SeqNum = s2.Uint64(startSeqNum) // resume — 0 means replay from start!
}
```

So a custom cache that followed the docs made `InputStartSeqNumLatest` replay from sequence 0 instead of tailing. Redis/SQL caches were unaffected only because their backends naturally return errors on miss (`redis.Nil`, `sql.ErrNoRows`).

## Changes
- **Corrected the `SeqNumCache` doc**: a miss must return a non-nil error (`ErrNoCacheEntry` is idiomatic); explicitly notes that `(0, nil)` is interpreted as "resume from 0" and breaks `InputStartSeqNumLatest`.
- **Made the wrapper match the doc**: a clean miss signalled via `ErrNoCacheEntry` no longer logs the misleading "Cache lookup failed" warning; only genuine backend errors do. Backward compatible — Redis/SQL behavior unchanged.
- **Added unit tests** covering both branches (`ErrNoCacheEntry` → no warning; other error → one warning), both surfacing as `ErrNoCacheEntry`.

## Notes
The repo's own `mapCache` test fixture already returns `ErrNoCacheEntry` on miss — the de-facto contract — so only the documentation was out of step with the code. Build, vet, and the full `s2-bentobox` test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)