### PR TITLE
fix(bentobox): keep in-memory tail position when durable cache write fails (#312)

### DIFF
--- a/s2-bentobox/input.go
+++ b/s2-bentobox/input.go
@@ -85,12 +85,14 @@ func (s *seqNumCache) Get(ctx context.Context, stream string) (uint64, error) {
 }
 
 func (s *seqNumCache) Set(ctx context.Context, stream string, seqNum uint64) error {
+	// Update the in-memory position even if the durable write fails, so the
+	// process keeps the latest position and a 416 reset to the tail isn't lost.
+	s.mem.Set(stream, seqNum)
 	if s.inner != nil {
 		if err := s.inner.Set(ctx, stream, seqNum); err != nil {
 			return err
 		}
 	}
-	s.mem.Set(stream, seqNum)
 	return nil
 }
 

--- a/s2-bentobox/multi_stream_input.go
+++ b/s2-bentobox/multi_stream_input.go
@@ -251,11 +251,11 @@ func streamSourceRecvLoop(
 				logger.With("stream", stream, "tail_seq_num", rangeErr.Tail.SeqNum).
 					Warn("Cached position beyond stream tail, resetting to tail")
 				if setErr := cache.Set(ctx, stream, rangeErr.Tail.SeqNum); setErr != nil {
+					// cache.Set already updated the in-memory position to the
+					// tail, so don't Forget: that would fall back to the stale
+					// durable value and tight-loop on 416.
 					logger.With("stream", stream, "error", setErr).
-						Error("Failed to reset cached sequence number after 416")
-					// Drop the stale in-memory entry so the next reconnect doesn't
-					// shadow the inner cache and tight-loop on 416.
-					cache.Forget(stream)
+						Error("Failed to durably reset cached sequence number after 416")
 				}
 				return
 			}

--- a/s2-bentobox/multi_stream_input_test.go
+++ b/s2-bentobox/multi_stream_input_test.go
@@ -263,16 +263,16 @@ func (f *failingSetCache) Set(context.Context, string, uint64) error {
 	return f.setErr
 }
 
-func TestStreamSourceRecvLoopForgetsStaleMemEntryWhenSetFails(t *testing.T) {
+func TestStreamSourceRecvLoopKeepsTailInMemWhenSetFails(t *testing.T) {
 	const stream = "demo"
 	const stale uint64 = 42
 	const tailSeqNum uint64 = 9001
 
+	// A durable cache stuck at a stale (beyond-tail) value whose writes fail.
 	inner := &failingSetCache{getValue: stale, setErr: errors.New("durable cache write failed")}
 	cache := newSeqNumCache(inner, silentLogger{})
 
-	// Warm the in-memory layer with the stale value (simulates prior successful
-	// Set that has since become stale relative to the stream tail).
+	// Warm the in-memory layer with the stale value.
 	if _, err := cache.Get(context.Background(), stream); err != nil {
 		t.Fatalf("warm cache: %v", err)
 	}
@@ -286,10 +286,18 @@ func TestStreamSourceRecvLoopForgetsStaleMemEntryWhenSetFails(t *testing.T) {
 
 	streamSourceRecvLoop(context.Background(), src, cache, stream, inputStream, silentLogger{})
 
-	// In-mem must be cleared so the next reconnect falls through to inner.Get
-	// instead of returning the stale value and tight-looping on 416.
-	if _, ok := cache.mem.Get(stream); ok {
-		t.Fatal("expected in-memory cache entry to be cleared after failed Set")
+	// The durable write failed, but the in-memory position must still be reset
+	// to the tail so the next reconnect doesn't fall back to the stale value.
+	if got, ok := cache.mem.Get(stream); !ok || got != tailSeqNum {
+		t.Fatalf("expected in-memory position reset to tail %d, got %d (present=%v)", tailSeqNum, got, ok)
+	}
+
+	got, err := cache.Get(context.Background(), stream)
+	if err != nil {
+		t.Fatalf("get after 416 reset: %v", err)
+	}
+	if got != tailSeqNum {
+		t.Fatalf("next reconnect should read from tail %d, got stale %d", tailSeqNum, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes #312.

On a 416 (range not satisfiable), `streamSourceRecvLoop` resets the cached position to the stream tail via `cache.Set`. If the durable backend write (`inner.Set`) failed, `seqNumCache.Set` returned without updating the in-memory layer, and the recv loop then called `cache.Forget`, dropping the in-memory entry. The next reconnect's `cache.Get` fell through to `inner.Get`, which still returned the stale (beyond-tail) value — so the consumer reconnected at the same position and **tight-looped on 416, making no progress**.

## The fix is two-sided
The issue's recommended fix (write `mem` even when `inner.Set` fails) is necessary but **not sufficient on its own**: the recv loop's `cache.Forget(stream)` would immediately wipe that corrected in-memory entry, so `Get` would still fall back to the stale `inner.Get`. Both halves must change:

1. **`seqNumCache.Set`** now updates the in-memory position **unconditionally**, before attempting the durable write. A failed durable write still leaves the running process at the correct position.
2. **The recv loop** no longer calls `cache.Forget` after a failed reset. Forgetting would discard the just-corrected in-memory tail and reintroduce the loop. The durable failure is still logged at Error level.

`Forget` remains in use for the stream-leaving path (unchanged).

## Tests
Renamed `TestStreamSourceRecvLoopForgetsStaleMemEntryWhenSetFails` → `TestStreamSourceRecvLoopKeepsTailInMemWhenSetFails`. The old test asserted the buggy behavior (mem cleared); it now asserts the in-memory position and a subsequent `cache.Get` both return the tail rather than the stale value. Build, vet, and the full `s2-bentobox` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)