### PR TITLE
fix(bentobox): drop stale acks that predate a 416 tail reset (#328)

### DIFF
--- a/s2-bentobox/input.go
+++ b/s2-bentobox/input.go
@@ -3,6 +3,7 @@ package bentobox
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	cmap "github.com/orcaman/concurrent-map/v2"
@@ -47,6 +48,18 @@ type seqNumCache struct {
 	// We don't trust the user to provide a valid cache so we have our own layer
 	// on top of the one provided by the user.
 	mem cmap.ConcurrentMap[string, uint64]
+	// Per-stream serialization and reset generation. A 416 tail reset bumps the
+	// generation; ack writes carry the generation captured when their read
+	// session started and are dropped if a newer reset has happened since (the
+	// ack predates the reset, so its position references records that are now
+	// beyond the tail). The mutex serializes a stream's generation check, mem
+	// write and durable write into one atomic step so a reset can't interleave.
+	gens cmap.ConcurrentMap[string, *streamGen]
+}
+
+type streamGen struct {
+	mu  sync.Mutex
+	gen uint64
 }
 
 func newSeqNumCache(inner SeqNumCache, logger Logger) *seqNumCache {
@@ -54,7 +67,29 @@ func newSeqNumCache(inner SeqNumCache, logger Logger) *seqNumCache {
 		inner:  inner,
 		logger: logger,
 		mem:    cmap.New[uint64](),
+		gens:   cmap.New[*streamGen](),
 	}
+}
+
+// streamGenFor returns the per-stream generation guard, creating it on first
+// use. Callers lock guard.mu before reading or mutating guard.gen.
+func (s *seqNumCache) streamGenFor(stream string) *streamGen {
+	return s.gens.Upsert(stream, nil, func(exists bool, cur, _ *streamGen) *streamGen {
+		if exists {
+			return cur
+		}
+		return &streamGen{}
+	})
+}
+
+// generation returns the current reset generation for stream. A read session
+// captures this when it starts and passes it back on ack (see toAckMap) so the
+// cache can reject acks that predate a later 416 tail reset.
+func (s *seqNumCache) generation(stream string) uint64 {
+	guard := s.streamGenFor(stream)
+	guard.mu.Lock()
+	defer guard.mu.Unlock()
+	return guard.gen
 }
 
 func (s *seqNumCache) Get(ctx context.Context, stream string) (uint64, error) {
@@ -84,9 +119,46 @@ func (s *seqNumCache) Get(ctx context.Context, stream string) (uint64, error) {
 	return cached, nil
 }
 
-func (s *seqNumCache) Set(ctx context.Context, stream string, seqNum uint64) error {
+// Set advances the cached position from an acknowledgement. gen is the reset
+// generation the acking session captured when it started reading; if a 416 tail
+// reset has bumped the stream's generation since then, the ack predates the
+// reset and is dropped, since persisting it would move the position back beyond
+// the tail and trigger another 416 on the next reconnect.
+func (s *seqNumCache) Set(ctx context.Context, stream string, seqNum, gen uint64) error {
+	guard := s.streamGenFor(stream)
+	guard.mu.Lock()
+	defer guard.mu.Unlock()
+
+	if gen < guard.gen {
+		s.logger.With("stream", stream, "seq_num", seqNum).
+			Debug("Dropping stale ack from a session that predates a 416 tail reset")
+		return nil
+	}
+
 	// Update the in-memory position even if the durable write fails, so the
-	// process keeps the latest position and a 416 reset to the tail isn't lost.
+	// process keeps the latest position.
+	s.mem.Set(stream, seqNum)
+	if s.inner != nil {
+		if err := s.inner.Set(ctx, stream, seqNum); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ResetToTail moves the cached position to the stream tail after a 416. Unlike
+// Set it may move the position backward, and it bumps the stream's reset
+// generation so any in-flight ack from a session started before the reset is
+// dropped rather than allowed to clobber the corrected tail position.
+func (s *seqNumCache) ResetToTail(ctx context.Context, stream string, seqNum uint64) error {
+	guard := s.streamGenFor(stream)
+	guard.mu.Lock()
+	defer guard.mu.Unlock()
+
+	guard.gen++
+
+	// Update the in-memory position even if the durable write fails, so the
+	// process keeps the tail position and the reset isn't lost.
 	s.mem.Set(stream, seqNum)
 	if s.inner != nil {
 		if err := s.inner.Set(ctx, stream, seqNum); err != nil {

--- a/s2-bentobox/input.go
+++ b/s2-bentobox/input.go
@@ -48,12 +48,11 @@ type seqNumCache struct {
 	// We don't trust the user to provide a valid cache so we have our own layer
 	// on top of the one provided by the user.
 	mem cmap.ConcurrentMap[string, uint64]
-	// Per-stream serialization and reset generation. A 416 tail reset bumps the
-	// generation; ack writes carry the generation captured when their read
-	// session started and are dropped if a newer reset has happened since (the
-	// ack predates the reset, so its position references records that are now
-	// beyond the tail). The mutex serializes a stream's generation check, mem
-	// write and durable write into one atomic step so a reset can't interleave.
+	// A 416 tail reset bumps a stream's generation. Acks carry the generation
+	// captured when their session started and are dropped if it's now stale, so
+	// an ack from before a reset can't clobber the corrected tail position. The
+	// mutex makes a stream's generation check, mem write and durable write one
+	// atomic step.
 	gens cmap.ConcurrentMap[string, *streamGen]
 }
 
@@ -71,8 +70,6 @@ func newSeqNumCache(inner SeqNumCache, logger Logger) *seqNumCache {
 	}
 }
 
-// streamGenFor returns the per-stream generation guard, creating it on first
-// use. Callers lock guard.mu before reading or mutating guard.gen.
 func (s *seqNumCache) streamGenFor(stream string) *streamGen {
 	return s.gens.Upsert(stream, nil, func(exists bool, cur, _ *streamGen) *streamGen {
 		if exists {
@@ -82,9 +79,6 @@ func (s *seqNumCache) streamGenFor(stream string) *streamGen {
 	})
 }
 
-// generation returns the current reset generation for stream. A read session
-// captures this when it starts and passes it back on ack (see toAckMap) so the
-// cache can reject acks that predate a later 416 tail reset.
 func (s *seqNumCache) generation(stream string) uint64 {
 	guard := s.streamGenFor(stream)
 	guard.mu.Lock()
@@ -119,24 +113,19 @@ func (s *seqNumCache) Get(ctx context.Context, stream string) (uint64, error) {
 	return cached, nil
 }
 
-// Set advances the cached position from an acknowledgement. gen is the reset
-// generation the acking session captured when it started reading; if a 416 tail
-// reset has bumped the stream's generation since then, the ack predates the
-// reset and is dropped, since persisting it would move the position back beyond
-// the tail and trigger another 416 on the next reconnect.
+// Set advances the cached position from an ack. gen is dropped if it's older
+// than the stream's current generation: the ack predates a 416 reset and would
+// move the position back beyond the tail.
 func (s *seqNumCache) Set(ctx context.Context, stream string, seqNum, gen uint64) error {
 	guard := s.streamGenFor(stream)
 	guard.mu.Lock()
 	defer guard.mu.Unlock()
 
 	if gen < guard.gen {
-		s.logger.With("stream", stream, "seq_num", seqNum).
-			Debug("Dropping stale ack from a session that predates a 416 tail reset")
+		s.logger.With("stream", stream, "seq_num", seqNum).Debug("Dropping ack from before a 416 tail reset")
 		return nil
 	}
 
-	// Update the in-memory position even if the durable write fails, so the
-	// process keeps the latest position.
 	s.mem.Set(stream, seqNum)
 	if s.inner != nil {
 		if err := s.inner.Set(ctx, stream, seqNum); err != nil {
@@ -147,9 +136,9 @@ func (s *seqNumCache) Set(ctx context.Context, stream string, seqNum, gen uint64
 }
 
 // ResetToTail moves the cached position to the stream tail after a 416. Unlike
-// Set it may move the position backward, and it bumps the stream's reset
-// generation so any in-flight ack from a session started before the reset is
-// dropped rather than allowed to clobber the corrected tail position.
+// Set it may move backward, and it bumps the generation so in-flight acks from
+// before the reset are dropped. mem is written even if the durable write fails,
+// so the reset survives in-process.
 func (s *seqNumCache) ResetToTail(ctx context.Context, stream string, seqNum uint64) error {
 	guard := s.streamGenFor(stream)
 	guard.mu.Lock()
@@ -157,8 +146,6 @@ func (s *seqNumCache) ResetToTail(ctx context.Context, stream string, seqNum uin
 
 	guard.gen++
 
-	// Update the in-memory position even if the durable write fails, so the
-	// process keeps the tail position and the reset isn't lost.
 	s.mem.Set(stream, seqNum)
 	if s.inner != nil {
 		if err := s.inner.Set(ctx, stream, seqNum); err != nil {

--- a/s2-bentobox/multi_stream_input.go
+++ b/s2-bentobox/multi_stream_input.go
@@ -250,8 +250,8 @@ func streamSourceRecvLoop(
 			if errors.As(err, &rangeErr) && rangeErr.Tail != nil {
 				logger.With("stream", stream, "tail_seq_num", rangeErr.Tail.SeqNum).
 					Warn("Cached position beyond stream tail, resetting to tail")
-				if setErr := cache.Set(ctx, stream, rangeErr.Tail.SeqNum); setErr != nil {
-					// cache.Set already updated the in-memory position to the
+				if setErr := cache.ResetToTail(ctx, stream, rangeErr.Tail.SeqNum); setErr != nil {
+					// ResetToTail already updated the in-memory position to the
 					// tail, so don't Forget: that would fall back to the stale
 					// durable value and tight-loop on 416.
 					logger.With("stream", stream, "error", setErr).

--- a/s2-bentobox/multi_stream_input_test.go
+++ b/s2-bentobox/multi_stream_input_test.go
@@ -109,10 +109,8 @@ func TestStreamSourceRecvLoopResetsCacheOn416(t *testing.T) {
 	}
 }
 
-// Regression for #328: an ack from a session that started before a 416 tail
-// reset lands asynchronously after the reset. It must not overwrite the
-// corrected tail position in either the in-memory or durable cache, otherwise
-// the next reconnect reads a beyond-tail position and hits 416 again.
+// Regression for #328: an ack from a session that predates a 416 tail reset
+// must not overwrite the corrected tail position in mem or durable cache.
 func TestStaleAckDoesNotOverwrite416TailReset(t *testing.T) {
 	const stream = "demo"
 	const tailSeqNum uint64 = 100
@@ -121,7 +119,6 @@ func TestStaleAckDoesNotOverwrite416TailReset(t *testing.T) {
 	inner := &mapCache{data: map[string]uint64{stream: staleSeqNum}}
 	cache := newSeqNumCache(inner, silentLogger{})
 
-	// The old session captured the pre-reset generation.
 	oldSi := &streamInput{
 		Stream:   stream,
 		cache:    cache,
@@ -148,7 +145,6 @@ func TestStaleAckDoesNotOverwrite416TailReset(t *testing.T) {
 		t.Fatalf("after 416, expected mem at tail %d, got %d (present=%v)", tailSeqNum, got, ok)
 	}
 
-	// The stale ack now completes; it predates the reset and must be dropped.
 	if err := ackFunc(context.Background(), nil); err != nil {
 		t.Fatalf("stale ack returned error: %v", err)
 	}
@@ -162,7 +158,7 @@ func TestStaleAckDoesNotOverwrite416TailReset(t *testing.T) {
 }
 
 // A session started after a 416 reset captures the bumped generation, so its
-// acks advance the cache normally rather than being dropped as stale.
+// acks advance the cache normally.
 func TestAckAfterTailResetAdvancesCache(t *testing.T) {
 	const stream = "demo"
 	const tailSeqNum uint64 = 100

--- a/s2-bentobox/multi_stream_input_test.go
+++ b/s2-bentobox/multi_stream_input_test.go
@@ -73,7 +73,7 @@ func TestStreamSourceRecvLoopResetsCacheOn416(t *testing.T) {
 		results: []readResult{{err: rangeErr}},
 	}
 	cache := newSeqNumCache(nil, silentLogger{})
-	if err := cache.Set(context.Background(), stream, 42); err != nil {
+	if err := cache.Set(context.Background(), stream, 42, 0); err != nil {
 		t.Fatalf("seed cache failed: %v", err)
 	}
 
@@ -109,6 +109,96 @@ func TestStreamSourceRecvLoopResetsCacheOn416(t *testing.T) {
 	}
 }
 
+// Regression for #328: an ack from a session that started before a 416 tail
+// reset lands asynchronously after the reset. It must not overwrite the
+// corrected tail position in either the in-memory or durable cache, otherwise
+// the next reconnect reads a beyond-tail position and hits 416 again.
+func TestStaleAckDoesNotOverwrite416TailReset(t *testing.T) {
+	const stream = "demo"
+	const tailSeqNum uint64 = 100
+	const staleSeqNum uint64 = 500
+
+	inner := &mapCache{data: map[string]uint64{stream: staleSeqNum}}
+	cache := newSeqNumCache(inner, silentLogger{})
+
+	// The old session captured the pre-reset generation.
+	oldSi := &streamInput{
+		Stream:   stream,
+		cache:    cache,
+		toAck:    newToAckMap(stream, cache, cache.generation(stream), silentLogger{}),
+		nacks:    make(chan []s2.SequencedRecord, 8),
+		Logger:   silentLogger{},
+		closedCh: make(chan struct{}),
+	}
+
+	records := []s2.SequencedRecord{{SeqNum: staleSeqNum - 2}, {SeqNum: staleSeqNum - 1}, {SeqNum: staleSeqNum}}
+	_, ackFunc, err := oldSi.handleBatch(context.Background(), records)
+	if err != nil {
+		t.Fatalf("handleBatch: %v", err)
+	}
+
+	rangeErr := &s2.RangeNotSatisfiableError{
+		S2Error: &s2.S2Error{Status: 416, Code: "RANGE_NOT_SATISFIABLE", Origin: "server"},
+		Tail:    &s2.StreamPosition{SeqNum: tailSeqNum},
+	}
+	src := &fakeBatchSource{results: []readResult{{err: rangeErr}}}
+	streamSourceRecvLoop(context.Background(), src, cache, stream, make(chan recvOutput, 1), silentLogger{})
+
+	if got, ok := cache.mem.Get(stream); !ok || got != tailSeqNum {
+		t.Fatalf("after 416, expected mem at tail %d, got %d (present=%v)", tailSeqNum, got, ok)
+	}
+
+	// The stale ack now completes; it predates the reset and must be dropped.
+	if err := ackFunc(context.Background(), nil); err != nil {
+		t.Fatalf("stale ack returned error: %v", err)
+	}
+
+	if got, ok := cache.mem.Get(stream); !ok || got != tailSeqNum {
+		t.Errorf("stale ack corrupted mem: expected tail %d, got %d", tailSeqNum, got)
+	}
+	if got, err := inner.Get(context.Background(), stream); err != nil || got != tailSeqNum {
+		t.Errorf("stale ack corrupted durable cache: expected tail %d, got %d (err=%v)", tailSeqNum, got, err)
+	}
+}
+
+// A session started after a 416 reset captures the bumped generation, so its
+// acks advance the cache normally rather than being dropped as stale.
+func TestAckAfterTailResetAdvancesCache(t *testing.T) {
+	const stream = "demo"
+	const tailSeqNum uint64 = 100
+
+	inner := &mapCache{data: map[string]uint64{}}
+	cache := newSeqNumCache(inner, silentLogger{})
+
+	if err := cache.ResetToTail(context.Background(), stream, tailSeqNum); err != nil {
+		t.Fatalf("reset to tail: %v", err)
+	}
+
+	newSi := &streamInput{
+		Stream:   stream,
+		cache:    cache,
+		toAck:    newToAckMap(stream, cache, cache.generation(stream), silentLogger{}),
+		nacks:    make(chan []s2.SequencedRecord, 8),
+		Logger:   silentLogger{},
+		closedCh: make(chan struct{}),
+	}
+
+	records := []s2.SequencedRecord{{SeqNum: tailSeqNum}, {SeqNum: tailSeqNum + 1}}
+	if _, ackFunc, err := newSi.handleBatch(context.Background(), records); err != nil {
+		t.Fatalf("handleBatch: %v", err)
+	} else if err := ackFunc(context.Background(), nil); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+
+	want := tailSeqNum + 2
+	if got, ok := cache.mem.Get(stream); !ok || got != want {
+		t.Errorf("expected mem advanced to %d, got %d", want, got)
+	}
+	if got, err := inner.Get(context.Background(), stream); err != nil || got != want {
+		t.Errorf("expected durable cache advanced to %d, got %d (err=%v)", want, got, err)
+	}
+}
+
 func TestStreamSourceRecvLoopForwardsOtherErrors(t *testing.T) {
 	const stream = "demo"
 	otherErr := errors.New("boom")
@@ -117,7 +207,7 @@ func TestStreamSourceRecvLoopForwardsOtherErrors(t *testing.T) {
 		results: []readResult{{err: otherErr}},
 	}
 	cache := newSeqNumCache(nil, silentLogger{})
-	if err := cache.Set(context.Background(), stream, 42); err != nil {
+	if err := cache.Set(context.Background(), stream, 42, 0); err != nil {
 		t.Fatalf("seed cache failed: %v", err)
 	}
 
@@ -163,7 +253,7 @@ func TestStreamSourceRecvLoopForwards416WhenTailMissing(t *testing.T) {
 		results: []readResult{{err: rangeErr}},
 	}
 	cache := newSeqNumCache(nil, silentLogger{})
-	if err := cache.Set(context.Background(), stream, 42); err != nil {
+	if err := cache.Set(context.Background(), stream, 42, 0); err != nil {
 		t.Fatalf("seed cache failed: %v", err)
 	}
 
@@ -197,7 +287,7 @@ func TestStreamSourceRecvLoopForwards416WhenTailMissing(t *testing.T) {
 
 func TestSeqNumCacheForgetDropsInMemoryEntry(t *testing.T) {
 	cache := newSeqNumCache(nil, silentLogger{})
-	if err := cache.Set(context.Background(), "s", 7); err != nil {
+	if err := cache.Set(context.Background(), "s", 7, 0); err != nil {
 		t.Fatalf("set: %v", err)
 	}
 

--- a/s2-bentobox/stream_input.go
+++ b/s2-bentobox/stream_input.go
@@ -21,16 +21,22 @@ type batchAckStatus struct {
 type toAckMap struct {
 	stream string
 	logger Logger
+	// gen is the cache reset generation captured when the owning read session
+	// started. It is passed back on every cache write so acks that predate a
+	// 416 tail reset (which bumps the generation) are dropped instead of
+	// clobbering the corrected position.
+	gen uint64
 
 	mu    sync.Mutex
 	inner *btree.Map[uint64, batchAckStatus]
 	cache *seqNumCache
 }
 
-func newToAckMap(stream string, cache *seqNumCache, logger Logger) *toAckMap {
+func newToAckMap(stream string, cache *seqNumCache, gen uint64, logger Logger) *toAckMap {
 	return &toAckMap{
 		stream: stream,
 		logger: logger,
+		gen:    gen,
 		inner:  btree.NewMap[uint64, batchAckStatus](2),
 		cache:  cache,
 	}
@@ -101,7 +107,7 @@ func (tam *toAckMap) MarkDone(ctx context.Context, records []s2.SequencedRecord,
 	if lastAcked != nil && updateCache {
 		nextSeqNum := lastAcked.LastSeqNum + 1
 		tam.logger.With("stream", tam.stream, "start_seq_num", nextSeqNum).Debug("Updating cached sequence number")
-		if err := tam.cache.Set(ctx, tam.stream, nextSeqNum); err != nil {
+		if err := tam.cache.Set(ctx, tam.stream, nextSeqNum, tam.gen); err != nil {
 			return err
 		}
 	}
@@ -141,6 +147,10 @@ func connectStreamInput(
 	// ErrNoCacheEntry (no entry, or inner error logged as warning); it never
 	// surfaces raw user cache errors here.
 	startSeqNum, err := cache.Get(ctx, stream)
+	// Capture the reset generation after reading the start position so this
+	// session's own acks are never dropped: a 416 reset racing in here only
+	// raises the generation, and an ack carrying the higher value still passes.
+	gen := cache.generation(stream)
 	if errors.Is(err, ErrNoCacheEntry) {
 		// No cache entry: use the configured default start position.
 		if inputStartSeqNum == InputStartSeqNumLatest {
@@ -170,7 +180,7 @@ func connectStreamInput(
 		Stream:       stream,
 		session:      session,
 		cache:        cache,
-		toAck:        newToAckMap(stream, cache, logger),
+		toAck:        newToAckMap(stream, cache, gen, logger),
 		nacks:        make(chan []s2.SequencedRecord, maxInflight),
 		Logger:       logger,
 		closeSession: closeSession,

--- a/s2-bentobox/stream_input.go
+++ b/s2-bentobox/stream_input.go
@@ -21,10 +21,8 @@ type batchAckStatus struct {
 type toAckMap struct {
 	stream string
 	logger Logger
-	// gen is the cache reset generation captured when the owning read session
-	// started. It is passed back on every cache write so acks that predate a
-	// 416 tail reset (which bumps the generation) are dropped instead of
-	// clobbering the corrected position.
+	// Cache generation captured when the session started, passed back on acks
+	// so the cache can drop ones that predate a 416 tail reset.
 	gen uint64
 
 	mu    sync.Mutex
@@ -147,9 +145,8 @@ func connectStreamInput(
 	// ErrNoCacheEntry (no entry, or inner error logged as warning); it never
 	// surfaces raw user cache errors here.
 	startSeqNum, err := cache.Get(ctx, stream)
-	// Capture the reset generation after reading the start position so this
-	// session's own acks are never dropped: a 416 reset racing in here only
-	// raises the generation, and an ack carrying the higher value still passes.
+	// After Get, so a 416 racing in only raises the generation we capture and
+	// this session's own acks are never dropped as stale.
 	gen := cache.generation(stream)
 	if errors.Is(err, ErrNoCacheEntry) {
 		// No cache entry: use the configured default start position.

--- a/s2-bentobox/stream_input_test.go
+++ b/s2-bentobox/stream_input_test.go
@@ -14,7 +14,7 @@ func newTestStreamInput() *streamInput {
 	return &streamInput{
 		Stream:   "demo",
 		cache:    cache,
-		toAck:    newToAckMap("demo", cache, silentLogger{}),
+		toAck:    newToAckMap("demo", cache, 0, silentLogger{}),
 		nacks:    make(chan []s2.SequencedRecord, 8),
 		Logger:   silentLogger{},
 		closedCh: make(chan struct{}),
@@ -114,7 +114,7 @@ func TestAckAfterCloseDoesNotUpdateCache(t *testing.T) {
 	si := &streamInput{
 		Stream:   stream,
 		cache:    cache,
-		toAck:    newToAckMap(stream, cache, silentLogger{}),
+		toAck:    newToAckMap(stream, cache, 0, silentLogger{}),
 		nacks:    make(chan []s2.SequencedRecord, 8),
 		Logger:   silentLogger{},
 		closedCh: make(chan struct{}),


### PR DESCRIPTION
## Summary
Fixes #328.

A 416 (`RangeNotSatisfiableError`) resets the cached read position to the stream tail via the shared `seqNumCache`. Since #326 made the in-memory write unconditional, an ack from a session that **started before** the reset could land asynchronously **after** it and overwrite the corrected tail position — re-triggering 416 on the next reconnect (and persisting across process restarts when the durable write also succeeded). Up to `maxInflight` extra 416 cycles per stream recreation.

## Why the issue's recommended fix is insufficient
The report suggests a forward-only `Set` (reject `seqNum <= current`). That only blocks **backward** moves. In the actual failure the stale ack (`501`) is **ahead** of the new tail (`100`), so a forward-only guard still lets it overwrite. Value alone cannot distinguish a stale pre-reset ack from a legitimate new-session ack — you need ordering information.

## Fix — per-stream reset generation
Split the two callers of `seqNumCache.Set`, which had conflicting semantics:

- **`Set` (ack path)** now carries the reset *generation* captured when the acking session started. If a later 416 reset has bumped the stream's generation, the ack predates the reset and is dropped.
- **`ResetToTail` (416 path)** bumps the generation and may move the position backward to the tail.

A per-stream mutex makes the generation check + in-memory write + durable write atomic, so a reset cannot interleave — fixing both the in-memory and the cross-restart durable corruption the issue calls out.

`connectStreamInput` captures the generation *after* reading the start position (so a 416 racing in only raises the generation and a session's own acks are never wrongly dropped) and threads it through `toAckMap`.

The public `SeqNumCache` interface is unchanged; all changes are internal.

## Tests
- `TestStaleAckDoesNotOverwrite416TailReset` — regression for #328; confirmed to fail without the guard (mem and durable both corrupt to `501`), passes with it.
- `TestAckAfterTailResetAdvancesCache` — a session started after a reset still advances the cache normally.
- `go build`, full `s2-bentobox` suite, `go test -race`, and `task lint` (0 issues) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)