### PR TITLE
feat: default account endpoint aws.s2.dev -> a.s2.dev

### DIFF
--- a/s2/client.go
+++ b/s2/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	DefaultBaseURL           = "https://aws.s2.dev/v1"
+	DefaultBaseURL           = "https://a.s2.dev/v1"
 	defaultRequestTimeout    = 5 * time.Second
 	defaultConnectionTimeout = 3 * time.Second
 
@@ -30,7 +30,7 @@ const (
 
 type ClientOptions struct {
 	// Endpoint to connect to S2.
-	// Defaults to "https://aws.s2.dev/v1".
+	// Defaults to "https://a.s2.dev/v1".
 	BaseURL string
 	// HTTP client used for requests.
 	HTTPClient *http.Client

--- a/s2/types.go
+++ b/s2/types.go
@@ -96,15 +96,12 @@ const (
 
 type AccessTokenInfo struct {
 	// Access token ID.
-	// It must be unique to the account and between 1 and 96 bytes in length.
 	ID AccessTokenID `json:"id"`
 	// Access token scope.
 	Scope AccessTokenScope `json:"scope"`
-	// Namespace streams based on the configured stream-level scope, which must be a prefix.
-	// Stream name arguments will be automatically prefixed, and the prefix will be stripped when listing streams.
+	// Namespace streams based on the configured stream-level scope.
 	AutoPrefixStreams bool `json:"auto_prefix_streams,omitempty"`
 	// Expiration time.
-	// If not set, the expiration will be set to that of the requestor's token.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 


### PR DESCRIPTION
Changes the default account endpoint (`DefaultBaseURL`) from `https://aws.s2.dev/v1` to `https://a.s2.dev/v1`. `aws.s2.dev` continues to serve, so existing configurations are unaffected.

Also carries the `s2-specs` submodule bump to `277e953` (supersedes #331).

🤖 Generated with [Claude Code](https://claude.com/claude-code)