### PR TITLE
perf: reuse zstd encoder and decoder across frames

### DIFF
--- a/internal/framing/decompress.go
+++ b/internal/framing/decompress.go
@@ -38,8 +38,9 @@ func gunzip(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Shared decoder for DecodeAll, which is safe for concurrent use.
-// Concurrency 0 keeps it goroutine-free since it never reads a stream.
+// Shared decoder for DecodeAll, which is safe for concurrent use and spawns
+// no goroutines (those are streaming-only). Concurrency 0 (GOMAXPROCS) sets
+// the number of pooled decoder states, bounding concurrent DecodeAll calls.
 var zstdDecoder = func() *zstd.Decoder {
 	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
 	if err != nil {

--- a/internal/framing/decompress.go
+++ b/internal/framing/decompress.go
@@ -38,16 +38,20 @@ func gunzip(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func unzstd(data []byte) ([]byte, error) {
-	decoder, err := zstd.NewReader(bytes.NewReader(data))
+// Shared decoder for DecodeAll, which is safe for concurrent use.
+// Concurrency 0 keeps it goroutine-free since it never reads a stream.
+var zstdDecoder = func() *zstd.Decoder {
+	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
 	if err != nil {
-		return nil, fmt.Errorf("zstd reader: %w", err)
+		panic(err)
 	}
-	defer decoder.Close()
+	return decoder
+}()
 
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, decoder); err != nil {
+func unzstd(data []byte) ([]byte, error) {
+	out, err := zstdDecoder.DecodeAll(data, nil)
+	if err != nil {
 		return nil, fmt.Errorf("zstd decompress: %w", err)
 	}
-	return buf.Bytes(), nil
+	return out, nil
 }

--- a/internal/framing/framing.go
+++ b/internal/framing/framing.go
@@ -273,12 +273,18 @@ func CreateFrameWithStatus(data []byte, terminal bool, compression CompressionTy
 	return frame
 }
 
-func compressZstd(data []byte) ([]byte, error) {
+// Shared encoder for EncodeAll, which is safe for concurrent use.
+// Creating an encoder per call allocates its full window each time.
+var zstdEncoder = func() *zstd.Encoder {
 	encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
-	return encoder.EncodeAll(data, nil), nil
+	return encoder
+}()
+
+func compressZstd(data []byte) ([]byte, error) {
+	return zstdEncoder.EncodeAll(data, nil), nil
 }
 
 func compressGzip(data []byte) ([]byte, error) {


### PR DESCRIPTION
A new zstd encoder/decoder was created for every frame. Use a shared encoder/decoder with `EncodeAll`/`DecodeAll` (safe for concurrent use) instead.

Benchmark on an ~11 KB payload:

| | before | after |
|---|---|---|
| compress | 338µs, 16 MB/op | 3.7µs, 11 KB/op |
| decompress | 11.3µs, 50 KB/op | 4.0µs, 11 KB/op |

🤖 Generated with [Claude Code](https://claude.com/claude-code)