### PR TITLE
perf: update read session state once per batch

### DIFF
--- a/s2/read.go
+++ b/s2/read.go
@@ -151,14 +151,12 @@ type streamReader struct {
 	nextTS     uint64
 	hasNextSeq bool
 
-	respBody       io.ReadCloser
-	bodyMu         sync.Mutex
-	recordsRead    uint64
-	bytesRead      uint64
-	startTime      time.Time
-	lastRecordTime time.Time
-	retryConfig    *RetryConfig
-	logger         *slog.Logger
+	respBody    io.ReadCloser
+	bodyMu      sync.Mutex
+	recordsRead uint64
+	bytesRead   uint64
+	retryConfig *RetryConfig
+	logger      *slog.Logger
 }
 
 func (s *StreamClient) newStreamReader(ctx context.Context, opts *ReadOptions) (*streamReader, error) {
@@ -177,19 +175,16 @@ func (s *StreamClient) newStreamReader(ctx context.Context, opts *ReadOptions) (
 
 	sessionCtx, sessionCancel := context.WithCancel(ctx)
 
-	now := time.Now()
 	session := &streamReader{
-		streamClient:   s,
-		recordsCh:      make(chan SequencedRecord, readSessionRecordsBuffer),
-		errorCh:        make(chan error, 1),
-		closed:         make(chan struct{}),
-		ctx:            sessionCtx,
-		cancel:         sessionCancel,
-		baseOpts:       cloneReadSessionOptions(opts),
-		startTime:      now,
-		lastRecordTime: now,
-		retryConfig:    retryCfg,
-		logger:         s.basinClient.logger,
+		streamClient: s,
+		recordsCh:    make(chan SequencedRecord, readSessionRecordsBuffer),
+		errorCh:      make(chan error, 1),
+		closed:       make(chan struct{}),
+		ctx:          sessionCtx,
+		cancel:       sessionCancel,
+		baseOpts:     cloneReadSessionOptions(opts),
+		retryConfig:  retryCfg,
+		logger:       s.basinClient.logger,
 	}
 
 	go session.run()
@@ -554,28 +549,36 @@ func (r *streamReader) runOnce(ctx context.Context, opts *ReadOptions) error {
 		}
 
 		ignoreCommandRecords := r.baseOpts != nil && r.baseOpts.IgnoreCommandRecords
-		for _, record := range batch.Records {
+		for i, record := range batch.Records {
 			if ignoreCommandRecords && record.IsCommandRecord() {
-				r.advanceState(record)
 				continue
 			}
 			if err := r.handleRecord(ctx, record); err != nil {
+				r.advanceState(batch.Records[:i])
 				return err
 			}
 		}
+		r.advanceState(batch.Records)
 
 		tailTimer.Reset(tailWatchdogTimeout)
 	}
 }
 
-func (r *streamReader) advanceState(record SequencedRecord) {
+func (r *streamReader) advanceState(records []SequencedRecord) {
+	if len(records) == 0 {
+		return
+	}
+	var meteredBytes uint64
+	for _, record := range records {
+		meteredBytes += MeteredSequencedRecordBytes(record)
+	}
+	last := records[len(records)-1]
 	r.stateMu.Lock()
-	r.recordsRead++
-	r.bytesRead += MeteredSequencedRecordBytes(record)
-	r.lastRecordTime = time.Now()
-	r.nextSeq = record.SeqNum + 1
+	r.recordsRead += uint64(len(records))
+	r.bytesRead += meteredBytes
+	r.nextSeq = last.SeqNum + 1
 	r.hasNextSeq = true
-	r.nextTS = record.Timestamp
+	r.nextTS = last.Timestamp
 	r.stateMu.Unlock()
 }
 
@@ -589,8 +592,6 @@ func (r *streamReader) handleRecord(ctx context.Context, record SequencedRecord)
 	}
 
 	logInfo(r.logger, "s2 read session record", "stream", string(r.streamClient.name), "seq_num", record.SeqNum)
-
-	r.advanceState(record)
 
 	return nil
 }

--- a/s2/read_session_retry_test.go
+++ b/s2/read_session_retry_test.go
@@ -23,13 +23,12 @@ func TestReadSessionBuildAttemptOptions_AdjustsLimits(t *testing.T) {
 			Wait:  Int32(baseWait),
 			Until: Uint64(baseUntil),
 		},
-		recordsRead:    4,
-		bytesRead:      40,
-		lastRecordTime: now.Add(-2 * time.Second),
-		lastTail:       &StreamPosition{SeqNum: 100},
-		lastTailAt:     now.Add(-2 * time.Second),
-		hasNextSeq:     true,
-		nextSeq:        7,
+		recordsRead: 4,
+		bytesRead:   40,
+		lastTail:    &StreamPosition{SeqNum: 100},
+		lastTailAt:  now.Add(-2 * time.Second),
+		hasNextSeq:  true,
+		nextSeq:     7,
 	}
 
 	opts := r.buildAttemptOptions(1 * time.Second)


### PR DESCRIPTION
`advanceState` ran per record: a `time.Now()` call and a `stateMu` lock/unlock for every record delivered. The timestamp fed `lastRecordTime`, which (like `startTime`) is never read anywhere — both fields are removed.

The remaining counters (`recordsRead`, `bytesRead`, `nextSeq`, `nextTS`) are now updated once per batch. If delivery stops mid-batch (session closed / context canceled), state is advanced for the exact prefix that was delivered, preserving the previous resume semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)