### PR TITLE
perf: deliver read session records to consumers one batch at a time

### DIFF
--- a/s2/read.go
+++ b/s2/read.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	tailWatchdogTimeout      = 20 * time.Second
-	readSessionRecordsBuffer = 100
+	readSessionBatchesBuffer = 10
 )
 
 var errSessionClosed = errors.New("read session closed")
@@ -134,7 +134,7 @@ func (s *StreamClient) Read(ctx context.Context, opts *ReadOptions) (*ReadBatch,
 type streamReader struct {
 	streamClient *StreamClient
 
-	recordsCh chan SequencedRecord
+	recordsCh chan []SequencedRecord
 	errorCh   chan error
 	closed    chan struct{}
 	closeOnce sync.Once
@@ -177,7 +177,7 @@ func (s *StreamClient) newStreamReader(ctx context.Context, opts *ReadOptions) (
 
 	session := &streamReader{
 		streamClient: s,
-		recordsCh:    make(chan SequencedRecord, readSessionRecordsBuffer),
+		recordsCh:    make(chan []SequencedRecord, readSessionBatchesBuffer),
 		errorCh:      make(chan error, 1),
 		closed:       make(chan struct{}),
 		ctx:          sessionCtx,
@@ -281,7 +281,7 @@ func (r *streamReader) run() {
 	}
 }
 
-func (r *streamReader) Records() <-chan SequencedRecord {
+func (r *streamReader) Records() <-chan []SequencedRecord {
 	return r.recordsCh
 }
 
@@ -548,33 +548,35 @@ func (r *streamReader) runOnce(ctx context.Context, opts *ReadOptions) error {
 			r.stateMu.Unlock()
 		}
 
-		ignoreCommandRecords := r.baseOpts != nil && r.baseOpts.IgnoreCommandRecords
-		for i, record := range batch.Records {
-			if ignoreCommandRecords && record.IsCommandRecord() {
-				continue
+		if len(batch.Records) > 0 {
+			// Snapshot full-batch accounting before filtering: limits and the
+			// resume position must reflect every record read, including command
+			// records that are filtered out of delivery.
+			recordCount := uint64(len(batch.Records))
+			var meteredBytes uint64
+			for _, record := range batch.Records {
+				meteredBytes += MeteredSequencedRecordBytes(record)
 			}
-			if err := r.handleRecord(ctx, record); err != nil {
-				r.advanceState(batch.Records[:i])
-				return err
+			last := batch.Records[len(batch.Records)-1]
+
+			if r.baseOpts != nil && r.baseOpts.IgnoreCommandRecords {
+				batch.filterCommandRecords()
 			}
+			if len(batch.Records) > 0 {
+				if err := r.sendBatch(ctx, batch.Records); err != nil {
+					return err
+				}
+			}
+			r.advanceState(recordCount, meteredBytes, last)
 		}
-		r.advanceState(batch.Records)
 
 		tailTimer.Reset(tailWatchdogTimeout)
 	}
 }
 
-func (r *streamReader) advanceState(records []SequencedRecord) {
-	if len(records) == 0 {
-		return
-	}
-	var meteredBytes uint64
-	for _, record := range records {
-		meteredBytes += MeteredSequencedRecordBytes(record)
-	}
-	last := records[len(records)-1]
+func (r *streamReader) advanceState(recordCount, meteredBytes uint64, last SequencedRecord) {
 	r.stateMu.Lock()
-	r.recordsRead += uint64(len(records))
+	r.recordsRead += recordCount
 	r.bytesRead += meteredBytes
 	r.nextSeq = last.SeqNum + 1
 	r.hasNextSeq = true
@@ -582,16 +584,14 @@ func (r *streamReader) advanceState(records []SequencedRecord) {
 	r.stateMu.Unlock()
 }
 
-func (r *streamReader) handleRecord(ctx context.Context, record SequencedRecord) error {
+func (r *streamReader) sendBatch(ctx context.Context, records []SequencedRecord) error {
 	select {
-	case r.recordsCh <- record:
+	case r.recordsCh <- records:
 	case <-r.closed:
 		return errSessionClosed
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-
-	logInfo(r.logger, "s2 read session record", "stream", string(r.streamClient.name), "seq_num", record.SeqNum)
 
 	return nil
 }

--- a/s2/read_session.go
+++ b/s2/read_session.go
@@ -86,6 +86,7 @@ func (s *ReadSession) yieldPending() bool {
 		return false
 	}
 	s.current = s.pending[0]
+	s.pending[0] = SequencedRecord{} // release references so consumed records can be collected
 	s.pending = s.pending[1:]
 	return true
 }

--- a/s2/read_session.go
+++ b/s2/read_session.go
@@ -7,6 +7,7 @@ import (
 
 type ReadSession struct {
 	reader  *streamReader
+	pending []SequencedRecord
 	current SequencedRecord
 	err     error
 	closed  atomic.Bool
@@ -30,9 +31,13 @@ func (s *ReadSession) Next() bool {
 		return false
 	}
 
+	if s.yieldPending() {
+		return true
+	}
+
 	for {
 		select {
-		case rec, ok := <-s.reader.Records():
+		case batch, ok := <-s.reader.Records():
 			if !ok {
 				// Records closed - drain any pending error before exiting
 				select {
@@ -45,19 +50,23 @@ func (s *ReadSession) Next() bool {
 				s.Close()
 				return false
 			}
-			s.current = rec
-			return true
+			s.pending = batch
+			if s.yieldPending() {
+				return true
+			}
 
 		case err, ok := <-s.reader.Errors():
 			if !ok {
 				select {
-				case rec, ok := <-s.reader.Records():
+				case batch, ok := <-s.reader.Records():
 					if !ok {
 						s.Close()
 						return false
 					}
-					s.current = rec
-					return true
+					s.pending = batch
+					if s.yieldPending() {
+						return true
+					}
 				default:
 					s.Close()
 					return false
@@ -70,6 +79,15 @@ func (s *ReadSession) Next() bool {
 			}
 		}
 	}
+}
+
+func (s *ReadSession) yieldPending() bool {
+	if len(s.pending) == 0 {
+		return false
+	}
+	s.current = s.pending[0]
+	s.pending = s.pending[1:]
+	return true
 }
 
 // Returns the most recent record fetched by Next.

--- a/s2/read_session_test.go
+++ b/s2/read_session_test.go
@@ -1,0 +1,141 @@
+package s2
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	pb "github.com/s2-streamstore/s2-sdk-go/generated"
+	internalframing "github.com/s2-streamstore/s2-sdk-go/internal/framing"
+	"google.golang.org/protobuf/proto"
+)
+
+func buildReadBatchFrame(t *testing.T, records []*pb.SequencedRecord) []byte {
+	t.Helper()
+	data, err := proto.Marshal(&pb.ReadBatch{Records: records})
+	if err != nil {
+		t.Fatalf("marshal read batch: %v", err)
+	}
+	return internalframing.CreateFrame(data, false, internalframing.CompressionNone)
+}
+
+func newFrameServedStreamClient(rt http.RoundTripper) *StreamClient {
+	basinClient := &BasinClient{
+		baseURL:     "http://example.com/v1",
+		accessToken: "token",
+		retryConfig: &RetryConfig{MaxAttempts: 2, MinBaseDelay: time.Millisecond, MaxBaseDelay: time.Millisecond},
+	}
+	basinClient.client = &Client{
+		streamingClient: &http.Client{Transport: rt},
+	}
+	return &StreamClient{
+		name:        StreamName("test"),
+		basinClient: basinClient,
+	}
+}
+
+func TestReadSessionDeliversRecordsInOrderAcrossBatches(t *testing.T) {
+	var body bytes.Buffer
+	body.Write(buildReadBatchFrame(t, []*pb.SequencedRecord{
+		{SeqNum: 0, Body: []byte("a")},
+		{SeqNum: 1, Body: []byte("b")},
+		{SeqNum: 2, Body: []byte("c")},
+	}))
+	body.Write(buildReadBatchFrame(t, []*pb.SequencedRecord{
+		{SeqNum: 3, Body: []byte("d")},
+		{SeqNum: 4, Body: []byte("e")},
+	}))
+	body.Write(internalframing.CreateFrameWithStatus(nil, true, internalframing.CompressionNone, http.StatusOK))
+
+	rt := &staticStatusRoundTripper{status: http.StatusOK, body: body.Bytes()}
+	streamClient := newFrameServedStreamClient(rt)
+
+	session, err := streamClient.ReadSession(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("failed to open read session: %v", err)
+	}
+	defer session.Close()
+
+	var got []uint64
+	for session.Next() {
+		got = append(got, session.Record().SeqNum)
+	}
+	if err := session.Err(); err != nil {
+		t.Fatalf("unexpected session error: %v", err)
+	}
+
+	want := []uint64{0, 1, 2, 3, 4}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d records, got %d (%v)", len(want), len(got), got)
+	}
+	for i, seq := range want {
+		if got[i] != seq {
+			t.Errorf("record %d: expected seq_num %d, got %d", i, seq, got[i])
+		}
+	}
+}
+
+func TestReadSessionIgnoreCommandRecordsSkipsDelivery(t *testing.T) {
+	var body bytes.Buffer
+	body.Write(buildReadBatchFrame(t, []*pb.SequencedRecord{
+		{SeqNum: 0, Body: []byte("a")},
+		{SeqNum: 1, Body: []byte("token"), Headers: []*pb.Header{{Name: nil, Value: []byte("fence")}}},
+		{SeqNum: 2, Body: []byte("b")},
+	}))
+	body.Write(internalframing.CreateFrameWithStatus(nil, true, internalframing.CompressionNone, http.StatusOK))
+
+	rt := &staticStatusRoundTripper{status: http.StatusOK, body: body.Bytes()}
+	streamClient := newFrameServedStreamClient(rt)
+
+	session, err := streamClient.ReadSession(context.Background(), &ReadOptions{IgnoreCommandRecords: true})
+	if err != nil {
+		t.Fatalf("failed to open read session: %v", err)
+	}
+	defer session.Close()
+
+	var got []uint64
+	for session.Next() {
+		got = append(got, session.Record().SeqNum)
+	}
+	if err := session.Err(); err != nil {
+		t.Fatalf("unexpected session error: %v", err)
+	}
+
+	if len(got) != 2 || got[0] != 0 || got[1] != 2 {
+		t.Fatalf("expected seq_nums [0 2], got %v", got)
+	}
+}
+
+func TestReadSessionNextReadPositionCountsFilteredRecords(t *testing.T) {
+	var body bytes.Buffer
+	body.Write(buildReadBatchFrame(t, []*pb.SequencedRecord{
+		{SeqNum: 0, Body: []byte("a")},
+		{SeqNum: 1, Body: []byte("token"), Headers: []*pb.Header{{Name: nil, Value: []byte("fence")}}},
+	}))
+	body.Write(internalframing.CreateFrameWithStatus(nil, true, internalframing.CompressionNone, http.StatusOK))
+
+	rt := &staticStatusRoundTripper{status: http.StatusOK, body: body.Bytes()}
+	streamClient := newFrameServedStreamClient(rt)
+
+	session, err := streamClient.ReadSession(context.Background(), &ReadOptions{IgnoreCommandRecords: true})
+	if err != nil {
+		t.Fatalf("failed to open read session: %v", err)
+	}
+	defer session.Close()
+
+	for session.Next() {
+	}
+	if err := session.Err(); err != nil {
+		t.Fatalf("unexpected session error: %v", err)
+	}
+
+	pos := session.NextReadPosition()
+	if pos == nil {
+		t.Fatalf("expected next read position, got nil")
+	}
+	if pos.SeqNum != 2 {
+		t.Errorf("expected next read position seq_num 2, got %d", pos.SeqNum)
+	}
+}


### PR DESCRIPTION
## Summary

The internal `streamReader` → `ReadSession` channel carried `SequencedRecord` values one at a time, so every record cost a channel send on the reader goroutine and a channel receive (inside a `select`) on the consumer side. This changes the channel to carry `[]SequencedRecord` — one send per parsed S2S frame — and `ReadSession.Next` drains the batch from a local slice between channel operations. The public API (`Next`/`Record`/`Err`) is unchanged.

Details:
- `advanceState` now takes the batch accounting (count, metered bytes, last record) as a snapshot captured before command-record filtering, so limit tracking and the resume position still count filtered records exactly as before.
- Command-record filtering moved from per-record checks in the delivery loop to `filterCommandRecords` on the parsed batch, applied before the send.
- The per-record `logInfo` call in the old `handleRecord` is gone; it allocated (arg boxing) on every record even when no logger was configured.
- Channel buffer is now 10 batches instead of 100 records, which increases prefetch for small-record streams while keeping worst-case buffered memory bounded by frame size (2 MiB each).

Delivery semantics note: the old loop could count partial progress if a send failed mid-batch, but sends only fail when the session is closing (context canceled or `Close`), which terminates the session — so batch-at-a-time accounting is behaviorally equivalent.

## Testing

- New unit tests deliver S2S frames through a fake transport and assert: in-order delivery across multiple batches, `IgnoreCommandRecords` filtering, and `NextReadPosition` counting filtered records (previously untested paths).
- `go test ./...` and `task lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)