### PR TITLE
perf: single-allocation CreateFrame and no double clone on the Producer path

### DIFF
--- a/internal/framing/create_frame_bench_test.go
+++ b/internal/framing/create_frame_bench_test.go
@@ -1,0 +1,20 @@
+package framing
+
+import (
+	"bytes"
+	"testing"
+)
+
+func benchmarkCreateFrame(b *testing.B, size int, terminal bool) {
+	data := bytes.Repeat([]byte{0xCD}, size)
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = CreateFrameWithStatus(data, terminal, CompressionNone, 200)
+	}
+}
+
+func BenchmarkCreateFrameSmall(b *testing.B)    { benchmarkCreateFrame(b, 512, false) }
+func BenchmarkCreateFrameLarge(b *testing.B)    { benchmarkCreateFrame(b, 1024*1024, false) }
+func BenchmarkCreateFrameTerminal(b *testing.B) { benchmarkCreateFrame(b, 512, true) }

--- a/internal/framing/framing.go
+++ b/internal/framing/framing.go
@@ -300,23 +300,21 @@ func CreateFrameWithStatus(data []byte, terminal bool, compression CompressionTy
 	}
 	flag |= byte(actualCompression) << flagCompressionShift
 
-	var payload []byte
+	headerLen := 4 // 3-byte length prefix + flag byte
 	if terminal {
-		payload = make([]byte, 1+2+len(compressedData))
-		payload[0] = flag
-		binary.BigEndian.PutUint16(payload[1:3], uint16(statusCode))
-		copy(payload[3:], compressedData)
-	} else {
-		payload = make([]byte, 1+len(compressedData))
-		payload[0] = flag
-		copy(payload[1:], compressedData)
+		headerLen += 2 // status code
 	}
+	payloadLen := headerLen - 3 + len(compressedData) // flag (+ status) + data
 
-	frame := make([]byte, 3+len(payload))
-	frame[0] = byte(len(payload) >> 16)
-	frame[1] = byte(len(payload) >> 8)
-	frame[2] = byte(len(payload))
-	copy(frame[3:], payload)
+	frame := make([]byte, headerLen+len(compressedData))
+	frame[0] = byte(payloadLen >> 16)
+	frame[1] = byte(payloadLen >> 8)
+	frame[2] = byte(payloadLen)
+	frame[3] = flag
+	if terminal {
+		binary.BigEndian.PutUint16(frame[4:6], uint16(statusCode))
+	}
+	copy(frame[headerLen:], compressedData)
 
 	return frame
 }

--- a/s2/append_prepare_bench_test.go
+++ b/s2/append_prepare_bench_test.go
@@ -1,0 +1,40 @@
+package s2
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Benchmarks the per-batch cost of the deep clone that the Producer path
+// previously paid in AppendSession.Submit on records the batcher already
+// owned, versus validation alone (the submitOwned path).
+func benchAppendInput() *AppendInput {
+	records := make([]AppendRecord, 1000)
+	body := bytes.Repeat([]byte{0xEF}, 1000)
+	for i := range records {
+		records[i] = AppendRecord{Body: body}
+	}
+	return &AppendInput{Records: records}
+}
+
+func BenchmarkPrepareAppendInputClone(b *testing.B) {
+	input := benchAppendInput()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, _, err := prepareAppendInput(input); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValidateAppendInput(b *testing.B) {
+	input := benchAppendInput()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := validateAppendInput(input); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/s2/append_session.go
+++ b/s2/append_session.go
@@ -96,6 +96,22 @@ func (r *AppendSession) Submit(input *AppendInput) (*SubmitFuture, error) {
 	return r.createSubmitFuture(prepared, size), nil
 }
 
+// submitOwned is Submit for inputs the caller exclusively owns and will not
+// mutate (e.g. batcher output on the Producer path, which is already deep
+// cloned on Add): it validates without the defensive clone.
+func (r *AppendSession) submitOwned(input *AppendInput) (*SubmitFuture, error) {
+	if r.closing.Load() {
+		return nil, ErrSessionClosed
+	}
+
+	size, err := validateAppendInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.createSubmitFuture(input, size), nil
+}
+
 func (r *AppendSession) createSubmitFuture(input *AppendInput, size int64) *SubmitFuture {
 	ticketCh := make(chan *BatchSubmitTicket, 1)
 	errCh := make(chan error, 1)

--- a/s2/batcher.go
+++ b/s2/batcher.go
@@ -42,6 +42,9 @@ func applyBatchingDefaults(opts *BatchingOptions) *BatchingOptions {
 		opts = &BatchingOptions{}
 	}
 	result := *opts
+	// Batch inputs reference this token without re-cloning it per batch, so
+	// detach it from the caller's pointer.
+	result.FencingToken = cloneStringPtr(result.FencingToken)
 	if result.Linger == 0 {
 		result.Linger = 5 * time.Millisecond
 	}

--- a/s2/producer.go
+++ b/s2/producer.go
@@ -71,8 +71,24 @@ func (p *Producer) consumeBatches() {
 	}
 }
 
+// ownedSubmitter is implemented by sessions that can skip the defensive deep
+// clone for inputs the caller exclusively owns.
+type ownedSubmitter interface {
+	submitOwned(input *AppendInput) (*SubmitFuture, error)
+}
+
 func (p *Producer) processBatch(batch *BatchOutput) {
-	future, err := p.session.Submit(batch.Input)
+	// The batcher deep-cloned every record on Add and this batch is its sole
+	// reference, so the session does not need to clone them again.
+	var (
+		future *SubmitFuture
+		err    error
+	)
+	if owned, ok := p.session.(ownedSubmitter); ok {
+		future, err = owned.submitOwned(batch.Input)
+	} else {
+		future, err = p.session.Submit(batch.Input)
+	}
 	if err != nil {
 		p.resolveBatchError(batch.recordMeta, err)
 		return

--- a/s2/stream.go
+++ b/s2/stream.go
@@ -223,26 +223,33 @@ const (
 	MaxFencingTokenLength = 36
 )
 
-func prepareAppendInput(input *AppendInput) (*AppendInput, int64, error) {
+func validateAppendInput(input *AppendInput) (int64, error) {
 	if input == nil {
-		return nil, 0, newValidationError("append input must not be nil")
+		return 0, newValidationError("append input must not be nil")
 	}
 	if len(input.Records) == 0 {
-		return nil, 0, newValidationError("append input must contain at least one record")
+		return 0, newValidationError("append input must contain at least one record")
 	}
 	if len(input.Records) > MaxBatchRecords {
-		return nil, 0, newValidationError(fmt.Sprintf("cannot append more than %d records at once, got %d", MaxBatchRecords, len(input.Records)))
+		return 0, newValidationError(fmt.Sprintf("cannot append more than %d records at once, got %d", MaxBatchRecords, len(input.Records)))
 	}
 	if input.FencingToken != nil && len(*input.FencingToken) > MaxFencingTokenLength {
-		return nil, 0, newValidationError(fmt.Sprintf("fencing token exceeds %d bytes in length", MaxFencingTokenLength))
+		return 0, newValidationError(fmt.Sprintf("fencing token exceeds %d bytes in length", MaxFencingTokenLength))
 	}
 
-	cloned := cloneAppendInput(input)
-	size := MeteredBatchBytes(cloned.Records)
+	size := MeteredBatchBytes(input.Records)
 	if size > MaxBatchMeteredBytes {
-		return nil, 0, newValidationError(fmt.Sprintf("batch size %d bytes exceeds maximum %d bytes (1 MiB)", size, MaxBatchMeteredBytes))
+		return 0, newValidationError(fmt.Sprintf("batch size %d bytes exceeds maximum %d bytes (1 MiB)", size, MaxBatchMeteredBytes))
 	}
-	return cloned, size, nil
+	return size, nil
+}
+
+func prepareAppendInput(input *AppendInput) (*AppendInput, int64, error) {
+	size, err := validateAppendInput(input)
+	if err != nil {
+		return nil, 0, err
+	}
+	return cloneAppendInput(input), size, nil
 }
 
 func cloneAppendInput(input *AppendInput) *AppendInput {


### PR DESCRIPTION
Two allocation fixes:

- `CreateFrameWithStatus` built the payload in one buffer and then copied it into a second buffer behind the length prefix. It now writes the header, flag, and status code directly into the final buffer — one allocation, one copy of the data. No API change.
- `Producer.Submit` deep-clones each record in `Batcher.Add`, and the flushed batch is the sole reference to those clones — but `processBatch` handed the batch to `AppendSession.Submit`, which deep-cloned every record again. Validation is now split out of `prepareAppendInput`, and an unexported `submitOwned` validates without cloning. The Producer uses it via an optional interface, so custom/mock sessions and the public `Submit` API keep the defensive clone. The batcher also detaches `FencingToken` from the caller's pointer at construction, since batch inputs now reference it without a per-batch clone.

Benchmarks for both paths are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)