### PR TITLE
perf: improve unary HTTP connection reuse

### DIFF
--- a/s2/client.go
+++ b/s2/client.go
@@ -103,17 +103,9 @@ func New(accessToken string, opts *ClientOptions) *Client {
 			connectionTimeout = defaultConnectionTimeout
 		}
 
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.DialContext = (&net.Dialer{
-			Timeout:   connectionTimeout,
-			KeepAlive: defaultTCPKeepAlive,
-		}).DialContext
-		transport.ForceAttemptHTTP2 = true
-		transport.MaxIdleConnsPerHost = defaultMaxIdleConnsPerHost
-
 		httpClient = &http.Client{
 			Timeout:   requestTimeout,
-			Transport: transport,
+			Transport: newUnaryHTTPTransport(http.DefaultTransport, connectionTimeout),
 		}
 	}
 	baseTransport := httpClient.Transport
@@ -171,6 +163,25 @@ func New(accessToken string, opts *ClientOptions) *Client {
 	c.Locations = &LocationsClient{client: c}
 
 	return c
+}
+
+func newUnaryHTTPTransport(base http.RoundTripper, connectionTimeout time.Duration) *http.Transport {
+	transport, ok := base.(*http.Transport)
+	if ok && transport != nil {
+		// Preserve the base transport's proxy, TLS, connection-pooling, and timeout settings.
+		transport = transport.Clone()
+	} else {
+		// http.DefaultTransport is replaceable, so its concrete type is not guaranteed.
+		transport = &http.Transport{}
+	}
+
+	transport.DialContext = (&net.Dialer{
+		Timeout:   connectionTimeout,
+		KeepAlive: defaultTCPKeepAlive,
+	}).DialContext
+	transport.ForceAttemptHTTP2 = true
+	transport.MaxIdleConnsPerHost = defaultMaxIdleConnsPerHost
+	return transport
 }
 
 type schemeAwareTransport struct {

--- a/s2/client.go
+++ b/s2/client.go
@@ -16,9 +16,11 @@ import (
 )
 
 const (
-	DefaultBaseURL           = "https://a.s2.dev/v1"
-	defaultRequestTimeout    = 5 * time.Second
-	defaultConnectionTimeout = 3 * time.Second
+	DefaultBaseURL             = "https://a.s2.dev/v1"
+	defaultRequestTimeout      = 5 * time.Second
+	defaultConnectionTimeout   = 3 * time.Second
+	defaultTCPKeepAlive        = 30 * time.Second
+	defaultMaxIdleConnsPerHost = 32
 
 	// HTTP/2 transport settings for streaming operations
 	http2MaxReadFrameSize  = 16 * 1024 * 1024
@@ -101,13 +103,17 @@ func New(accessToken string, opts *ClientOptions) *Client {
 			connectionTimeout = defaultConnectionTimeout
 		}
 
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = (&net.Dialer{
+			Timeout:   connectionTimeout,
+			KeepAlive: defaultTCPKeepAlive,
+		}).DialContext
+		transport.ForceAttemptHTTP2 = true
+		transport.MaxIdleConnsPerHost = defaultMaxIdleConnsPerHost
+
 		httpClient = &http.Client{
-			Timeout: requestTimeout,
-			Transport: &http.Transport{
-				DialContext: (&net.Dialer{
-					Timeout: connectionTimeout,
-				}).DialContext,
-			},
+			Timeout:   requestTimeout,
+			Transport: transport,
 		}
 	}
 	baseTransport := httpClient.Transport

--- a/s2/client_config_test.go
+++ b/s2/client_config_test.go
@@ -35,6 +35,74 @@ func TestClient_DefaultBaseURL(t *testing.T) {
 	}
 }
 
+func TestClient_DefaultHTTPTransport(t *testing.T) {
+	const requestTimeout = 17 * time.Second
+	client := New("token", &ClientOptions{
+		RequestTimeout:    requestTimeout,
+		ConnectionTimeout: 11 * time.Second,
+	})
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	if client.httpClient.Timeout != requestTimeout {
+		t.Fatalf("expected request timeout %s, got %s", requestTimeout, client.httpClient.Timeout)
+	}
+
+	userAgentTransport, ok := client.httpClient.Transport.(userAgentRoundTripper)
+	if !ok {
+		t.Fatalf("expected user-agent transport, got %T", client.httpClient.Transport)
+	}
+
+	transport, ok := userAgentTransport.base.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected HTTP transport, got %T", userAgentTransport.base)
+	}
+	if transport == http.DefaultTransport {
+		t.Fatal("expected the default transport to be cloned")
+	}
+	if !transport.ForceAttemptHTTP2 {
+		t.Fatal("expected HTTP/2 attempts to be enabled")
+	}
+	if transport.MaxIdleConnsPerHost != defaultMaxIdleConnsPerHost {
+		t.Fatalf("expected %d idle connections per host, got %d", defaultMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	}
+	if transport.MaxIdleConns != defaultTransport.MaxIdleConns {
+		t.Fatalf("expected default global idle connection limit %d, got %d", defaultTransport.MaxIdleConns, transport.MaxIdleConns)
+	}
+	if transport.IdleConnTimeout != defaultTransport.IdleConnTimeout {
+		t.Fatalf("expected default idle connection timeout %s, got %s", defaultTransport.IdleConnTimeout, transport.IdleConnTimeout)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected a configured dialer")
+	}
+}
+
+func TestClient_CustomHTTPClientPreserved(t *testing.T) {
+	customTransport := &basinHeaderRoundTripper{}
+	customClient := &http.Client{
+		Transport: customTransport,
+		Timeout:   23 * time.Second,
+	}
+
+	client := New("token", &ClientOptions{
+		HTTPClient:        customClient,
+		RequestTimeout:    time.Second,
+		ConnectionTimeout: time.Second,
+	})
+	if client.httpClient != customClient {
+		t.Fatal("expected the caller-provided HTTP client to be retained")
+	}
+	if client.httpClient.Timeout != 23*time.Second {
+		t.Fatalf("expected caller-provided timeout to be retained, got %s", client.httpClient.Timeout)
+	}
+
+	userAgentTransport, ok := client.httpClient.Transport.(userAgentRoundTripper)
+	if !ok {
+		t.Fatalf("expected user-agent transport, got %T", client.httpClient.Transport)
+	}
+	if userAgentTransport.base != customTransport {
+		t.Fatalf("expected caller-provided transport to be retained, got %T", userAgentTransport.base)
+	}
+}
+
 func TestClient_NormalizesBaseURL(t *testing.T) {
 	testCases := []struct {
 		name    string

--- a/s2/client_config_test.go
+++ b/s2/client_config_test.go
@@ -15,6 +15,12 @@ type basinHeaderRoundTripper struct {
 	requests int
 }
 
+type stubRoundTripper struct{}
+
+func (*stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	panic("unexpected request")
+}
+
 func (r *basinHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	r.requests++
 	r.header = req.Header.Get("s2-basin")
@@ -75,8 +81,35 @@ func TestClient_DefaultHTTPTransport(t *testing.T) {
 	}
 }
 
+func TestUnaryHTTPTransport_FallsBackForCustomDefault(t *testing.T) {
+	var nilTransport *http.Transport
+	testCases := []struct {
+		name string
+		base http.RoundTripper
+	}{
+		{name: "custom round tripper", base: &stubRoundTripper{}},
+		{name: "typed nil transport", base: nilTransport},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := newUnaryHTTPTransport(tc.base, 11*time.Second)
+
+			if transport.DialContext == nil {
+				t.Fatal("expected a configured dialer")
+			}
+			if !transport.ForceAttemptHTTP2 {
+				t.Fatal("expected HTTP/2 attempts to be enabled")
+			}
+			if transport.MaxIdleConnsPerHost != defaultMaxIdleConnsPerHost {
+				t.Fatalf("expected %d idle connections per host, got %d", defaultMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+			}
+		})
+	}
+}
+
 func TestClient_CustomHTTPClientPreserved(t *testing.T) {
-	customTransport := &basinHeaderRoundTripper{}
+	customTransport := &stubRoundTripper{}
 	customClient := &http.Client{
 		Transport: customTransport,
 		Timeout:   23 * time.Second,


### PR DESCRIPTION
## Summary

- clone Go's tuned default HTTP transport for SDK-created unary clients
- enable HTTP/2 negotiation and retain more idle connections per host
- safely fall back when http.DefaultTransport was replaced with a custom or typed-nil RoundTripper
- preserve caller-provided HTTP client behavior

## Compatibility

- SDK-created unary clients now inherit ProxyFromEnvironment, so HTTP_PROXY, HTTPS_PROXY, and NO_PROXY are honored
- streaming ReadSession and AppendSession clients still use direct HTTP/2 transports and are not configured through ClientOptions.HTTPClient

## Testing

- go test ./...
- go vet ./...