### PR TITLE
feat: add durable producer flush

### DIFF
--- a/s2/batcher.go
+++ b/s2/batcher.go
@@ -18,6 +18,7 @@ type Batcher struct {
 	timer           *time.Timer
 	timerSeq        uint64
 	closed          bool
+	closeErr        error
 	nextMatchSeqNum *uint64
 
 	batchesCh chan *BatchOutput
@@ -30,6 +31,7 @@ type BatchOutput struct {
 	// Input contains the records to append.
 	Input      *AppendInput
 	recordMeta []recordMeta
+	barrier    chan<- error
 }
 
 type recordMeta struct {
@@ -126,9 +128,9 @@ func (b *Batcher) Add(record AppendRecord, resultCh chan *producerOutcome) error
 	return nil
 }
 
-func (b *Batcher) flushLocked() {
+func (b *Batcher) flushLocked() error {
 	if len(b.buffer) == 0 {
-		return
+		return nil
 	}
 
 	records := make([]AppendRecord, len(b.buffer))
@@ -161,8 +163,12 @@ func (b *Batcher) flushLocked() {
 		if b.nextMatchSeqNum != nil {
 			*b.nextMatchSeqNum += uint64(len(records))
 		}
+		return nil
 	case <-b.ctx.Done():
 		err := b.ctx.Err()
+		if b.closeErr == nil {
+			b.closeErr = err
+		}
 		for _, m := range meta {
 			select {
 			case m.resultCh <- &producerOutcome{err: err}:
@@ -170,6 +176,32 @@ func (b *Batcher) flushLocked() {
 			default:
 			}
 		}
+		return err
+	}
+}
+
+// flushBarrier atomically emits the current partial batch and orders a
+// producer barrier after it. Holding mu across both sends prevents a
+// concurrent Add from landing between the batch and its barrier.
+func (b *Batcher) flushBarrier(barrier chan<- error) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return ErrSessionClosed
+	}
+	if err := b.flushLocked(); err != nil {
+		return err
+	}
+	if err := b.ctx.Err(); err != nil {
+		return err
+	}
+
+	select {
+	case b.batchesCh <- &BatchOutput{barrier: barrier}:
+		return nil
+	case <-b.ctx.Done():
+		return b.ctx.Err()
 	}
 }
 
@@ -191,28 +223,36 @@ func (b *Batcher) Batches() <-chan *BatchOutput {
 	return b.batchesCh
 }
 
-// Flush forces the current batch to be emitted immediately.
+// Flush forces the current batch to be emitted immediately. It does not wait
+// for the batch to become durable; use [Producer.Flush] for a durable barrier.
 func (b *Batcher) Flush() {
 	b.mu.Lock()
 	b.flushLocked()
 	b.mu.Unlock()
 }
 
-// Flushes any remaining records and closes the batcher.
-func (b *Batcher) Close() {
+func (b *Batcher) close() error {
 	b.mu.Lock()
 	if b.closed {
+		err := b.closeErr
 		b.mu.Unlock()
-		return
+		return err
 	}
 	b.closed = true
-	b.flushLocked()
+	_ = b.flushLocked()
 	if b.timer != nil {
 		b.timer.Stop()
 		b.timer = nil
 	}
+	err := b.closeErr
 	b.mu.Unlock()
 
 	b.cancel()
 	close(b.batchesCh)
+	return err
+}
+
+// Flushes any remaining records and closes the batcher.
+func (b *Batcher) Close() {
+	_ = b.close()
 }

--- a/s2/producer.go
+++ b/s2/producer.go
@@ -2,8 +2,10 @@ package s2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 // Producer provides per-record append semantics on top of a batched AppendSession.
@@ -11,12 +13,20 @@ import (
 //     has been accepted (written to the batcher). Backpressure is applied
 //     automatically via the batcher when the [AppendSession] is at capacity.
 //   - ticket.Ack() returns an IndexedAppendAck that resolves once the record is durable.
+//   - Flush() establishes a reusable durability boundary without closing the producer.
 type Producer struct {
-	batcher *Batcher
-	session appendSessionAPI
-	ctx     context.Context
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
+	batcher      *Batcher
+	session      appendSessionAPI
+	ctx          context.Context
+	cancel       context.CancelFunc
+	ackWG        sync.WaitGroup
+	consumerDone chan struct{}
+	errMu        sync.RWMutex
+	terminalErr  error
+	closing      atomic.Bool
+	closeOnce    sync.Once
+	closeDone    chan struct{}
+	closeErr     error
 }
 
 type appendSessionAPI interface {
@@ -36,13 +46,14 @@ func newProducerWithSession(ctx context.Context, batcher *Batcher, session appen
 	prodCtx, cancel := context.WithCancel(ctx)
 
 	p := &Producer{
-		batcher: batcher,
-		session: session,
-		ctx:     prodCtx,
-		cancel:  cancel,
+		batcher:      batcher,
+		session:      session,
+		ctx:          prodCtx,
+		cancel:       cancel,
+		consumerDone: make(chan struct{}),
+		closeDone:    make(chan struct{}),
 	}
 
-	p.wg.Add(1)
 	go p.consumeBatches()
 
 	return p
@@ -52,10 +63,25 @@ func newProducerWithSession(ctx context.Context, batcher *Batcher, session appen
 // Returns a [RecordSubmitFuture] that resolves to a RecordSubmitTicket once the record has been
 // accepted. Blocks if the underlying [AppendSession] is at capacity.
 func (p *Producer) Submit(record AppendRecord) (*RecordSubmitFuture, error) {
+	if err := p.terminalError(); err != nil {
+		return nil, err
+	}
+	if p.closing.Load() {
+		return nil, ErrSessionClosed
+	}
+	if err := p.ctx.Err(); err != nil {
+		return nil, p.recordTerminalError(err)
+	}
+
 	ticketCh := make(chan *RecordSubmitTicket, 1)
 	resultCh := make(chan *producerOutcome, 1)
 
 	if err := p.batcher.Add(record, resultCh); err != nil {
+		if errors.Is(err, ErrSessionClosed) {
+			if terminalErr := p.terminalError(); terminalErr != nil {
+				return nil, terminalErr
+			}
+		}
 		return nil, err
 	}
 	ticketCh <- &RecordSubmitTicket{ackCh: resultCh}
@@ -63,12 +89,83 @@ func (p *Producer) Submit(record AppendRecord) (*RecordSubmitFuture, error) {
 	return &RecordSubmitFuture{ticketCh: ticketCh}, nil
 }
 
+// Flush forces buffered records to be emitted and waits until every record
+// ordered before the barrier is durably acknowledged or one fails. Records
+// ordered after the barrier are excluded, and the Producer remains usable
+// after a successful Flush.
+//
+// Submit and Flush are ordered by the Batcher: a Submit that has completed
+// before Flush begins is covered, while calls made concurrently may land on
+// either side. An empty Flush succeeds without issuing an append. Canceling ctx
+// stops this call's wait, while ordering and draining the barrier continue in
+// the background. If a covered append fails, the error is terminal, closes the
+// Producer, and is returned by subsequent Submit, Flush, and Close calls.
+// Unlike [Batcher.Flush], this method waits for durable acknowledgments.
+func (p *Producer) Flush(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := p.terminalError(); err != nil {
+		return p.waitForTerminalDrain(ctx, err)
+	}
+	if p.closing.Load() {
+		return ErrSessionClosed
+	}
+	if err := p.ctx.Err(); err != nil {
+		terminalErr := p.recordTerminalError(err)
+		return p.waitForTerminalDrain(ctx, terminalErr)
+	}
+
+	barrier := make(chan error, 1)
+	ordered := make(chan error, 1)
+	go func() {
+		err := p.batcher.flushBarrier(barrier)
+		if err != nil && !errors.Is(err, ErrSessionClosed) {
+			err = p.recordTerminalError(err)
+		}
+		ordered <- err
+	}()
+
+	select {
+	case err := <-ordered:
+		if err == nil {
+			break
+		}
+		if errors.Is(err, ErrSessionClosed) {
+			if terminalErr := p.terminalError(); terminalErr != nil {
+				return p.waitForTerminalDrain(ctx, terminalErr)
+			}
+			return err
+		}
+		return p.waitForTerminalDrain(ctx, err)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-barrier:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (p *Producer) consumeBatches() {
-	defer p.wg.Done()
+	defer close(p.consumerDone)
 
 	for batch := range p.batcher.Batches() {
-		p.processBatch(batch)
+		if batch.Input != nil {
+			p.processBatch(batch)
+		}
+		if batch.barrier != nil {
+			p.ackWG.Wait()
+			batch.barrier <- p.terminalError()
+		}
 	}
+	p.ackWG.Wait()
 }
 
 // ownedSubmitter is implemented by sessions that can skip the defensive deep
@@ -78,6 +175,11 @@ type ownedSubmitter interface {
 }
 
 func (p *Producer) processBatch(batch *BatchOutput) {
+	if err := p.terminalError(); err != nil {
+		p.dispatchBatchError(batch.recordMeta, err)
+		return
+	}
+
 	// The batcher deep-cloned every record on Add and this batch is its sole
 	// reference, so the session does not need to clone them again.
 	var (
@@ -90,28 +192,71 @@ func (p *Producer) processBatch(batch *BatchOutput) {
 		future, err = p.session.Submit(batch.Input)
 	}
 	if err != nil {
-		p.resolveBatchError(batch.recordMeta, err)
+		p.resolveSynchronousBatchError(batch.recordMeta, err)
 		return
 	}
 
-	ticket, err := future.Wait(p.ctx)
+	ticket, err := p.waitForBatchSubmission(future)
 	if err != nil {
-		p.resolveBatchError(batch.recordMeta, err)
+		p.resolveSynchronousBatchError(batch.recordMeta, err)
 		return
 	}
 
-	p.wg.Add(1)
+	p.ackWG.Add(1)
 	go func() {
-		defer p.wg.Done()
+		defer p.ackWG.Done()
 
-		ack, err := ticket.Ack(p.ctx)
+		ack, err := p.waitForBatchAck(ticket)
 		if err != nil {
-			p.resolveBatchError(batch.recordMeta, err)
+			p.dispatchBatchError(batch.recordMeta, p.recordTerminalError(err))
 			return
 		}
 
 		p.resolveBatchAck(batch.recordMeta, ack)
 	}()
+}
+
+func (p *Producer) waitForBatchSubmission(future *SubmitFuture) (*BatchSubmitTicket, error) {
+	select {
+	case ticket := <-future.ticketCh:
+		return ticket, nil
+	case err := <-future.errCh:
+		return nil, err
+	case <-p.ctx.Done():
+		// Prefer a result that was already available when termination raced the
+		// select. This preserves the AppendSession's exact terminal cause.
+		select {
+		case ticket := <-future.ticketCh:
+			return ticket, nil
+		case err := <-future.errCh:
+			return nil, err
+		default:
+			return nil, p.ctx.Err()
+		}
+	}
+}
+
+func (p *Producer) waitForBatchAck(ticket *BatchSubmitTicket) (*AppendAck, error) {
+	result := func(outcome *inflightResult, ok bool) (*AppendAck, error) {
+		if !ok || outcome == nil {
+			return nil, fmt.Errorf("batch submit ticket resolved without a payload")
+		}
+		return outcome.ack, outcome.err
+	}
+
+	select {
+	case outcome, ok := <-ticket.ackCh:
+		return result(outcome, ok)
+	case <-p.ctx.Done():
+		// Drain a result that was already ready before falling back to the
+		// Producer's sticky terminal cause, matching ordered session shutdown.
+		select {
+		case outcome, ok := <-ticket.ackCh:
+			return result(outcome, ok)
+		default:
+			return nil, p.ctx.Err()
+		}
+	}
 }
 
 func (p *Producer) resolveBatchAck(meta []recordMeta, ack *AppendAck) {
@@ -128,7 +273,16 @@ func (p *Producer) resolveBatchAck(meta []recordMeta, ack *AppendAck) {
 	}
 }
 
-func (p *Producer) resolveBatchError(meta []recordMeta, err error) {
+func (p *Producer) resolveSynchronousBatchError(meta []recordMeta, err error) {
+	// Establish the failure before waiting so cancellation releases any earlier
+	// ticket waits. recordTerminalError preserves a cause already observed by an
+	// earlier batch and fans the chosen cause out to the remaining tickets.
+	terminalErr := p.recordTerminalError(err)
+	p.ackWG.Wait()
+	p.dispatchBatchError(meta, terminalErr)
+}
+
+func (p *Producer) dispatchBatchError(meta []recordMeta, err error) {
 	for _, m := range meta {
 		select {
 		case m.resultCh <- &producerOutcome{err: err}:
@@ -138,13 +292,71 @@ func (p *Producer) resolveBatchError(meta []recordMeta, err error) {
 	}
 }
 
+func (p *Producer) terminalError() error {
+	p.errMu.RLock()
+	defer p.errMu.RUnlock()
+	return p.terminalErr
+}
+
+func (p *Producer) recordTerminalError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	p.errMu.Lock()
+	first := p.terminalErr == nil
+	if first {
+		p.terminalErr = err
+	}
+	terminalErr := p.terminalErr
+	p.errMu.Unlock()
+
+	if first {
+		// Closing seals records that were already accepted into the Batcher and
+		// makes later submissions fail. Canceling the producer context also
+		// releases every outstanding ticket wait so they receive this same cause.
+		p.closing.Store(true)
+		p.cancel()
+		// This must be asynchronous because the consumer may need to drain a
+		// bounded batch channel for the batcher close to finish.
+		go func() { _ = p.batcher.close() }()
+	}
+
+	return terminalErr
+}
+
+func (p *Producer) waitForTerminalDrain(ctx context.Context, terminalErr error) error {
+	select {
+	case <-p.consumerDone:
+		return terminalErr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Stops the producer, flushes pending batches, and waits for in-flight acks.
-// Close blocks until in-flight work completes or the producer context is canceled.
+// Close blocks until in-flight work completes or the producer context is
+// canceled. It returns a terminal append error when one closed the Producer.
+// Close does not close the supplied AppendSession.
 func (p *Producer) Close() error {
-	p.batcher.Close()
-	p.wg.Wait()
-	p.cancel()
-	return nil
+	p.closeOnce.Do(func() {
+		p.closing.Store(true)
+		if err := p.batcher.close(); err != nil {
+			p.recordTerminalError(err)
+		}
+		<-p.consumerDone
+
+		// Check before calling cancel so a parent-context cancellation remains
+		// distinguishable from this method's normal cleanup cancellation.
+		if err := p.ctx.Err(); err != nil && p.terminalError() == nil {
+			p.recordTerminalError(err)
+		}
+		p.cancel()
+		p.closeErr = p.terminalError()
+		close(p.closeDone)
+	})
+	<-p.closeDone
+	return p.closeErr
 }
 
 // Represents a pending single-record submission to a [Producer].

--- a/s2/producer_flush_test.go
+++ b/s2/producer_flush_test.go
@@ -1,0 +1,383 @@
+package s2
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+)
+
+const flushTestTimeout = 5 * time.Second
+
+type controlledAppendCall struct {
+	input    *AppendInput
+	ticketCh chan *BatchSubmitTicket
+	errCh    chan error
+	ackCh    chan *inflightResult
+}
+
+func (c *controlledAppendCall) accept() {
+	c.ticketCh <- &BatchSubmitTicket{ackCh: c.ackCh}
+}
+
+func (c *controlledAppendCall) reject(err error) {
+	c.errCh <- err
+}
+
+func (c *controlledAppendCall) resolve(ack *AppendAck, err error) {
+	c.ackCh <- &inflightResult{ack: ack, err: err}
+	close(c.ackCh)
+}
+
+type controlledAppendSession struct {
+	calls chan *controlledAppendCall
+}
+
+func newControlledAppendSession() *controlledAppendSession {
+	return &controlledAppendSession{calls: make(chan *controlledAppendCall, 16)}
+}
+
+func (s *controlledAppendSession) Submit(input *AppendInput) (*SubmitFuture, error) {
+	call := &controlledAppendCall{
+		input:    input,
+		ticketCh: make(chan *BatchSubmitTicket, 1),
+		errCh:    make(chan error, 1),
+		ackCh:    make(chan *inflightResult, 1),
+	}
+	s.calls <- call
+	return &SubmitFuture{ticketCh: call.ticketCh, errCh: call.errCh}, nil
+}
+
+func (s *controlledAppendSession) Close() error { return nil }
+
+func submitRecord(t *testing.T, producer *Producer, body string) *RecordSubmitTicket {
+	t.Helper()
+	future, err := producer.Submit(AppendRecord{Body: []byte(body)})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	ticket, err := future.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	return ticket
+}
+
+func startFlush(producer *Producer, ctx context.Context) <-chan error {
+	done := make(chan error, 1)
+	go func() { done <- producer.Flush(ctx) }()
+	return done
+}
+
+func nextAppendCall(t *testing.T, session *controlledAppendSession) *controlledAppendCall {
+	t.Helper()
+	select {
+	case call := <-session.calls:
+		return call
+	case <-time.After(flushTestTimeout):
+		t.Fatal("append call timed out")
+		return nil
+	}
+}
+
+func waitFlush(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(flushTestTimeout):
+		t.Fatal("flush timed out")
+		return nil
+	}
+}
+
+func requireFlushPending(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		t.Fatalf("flush returned early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func readyOutcome(t *testing.T, ticket *RecordSubmitTicket) *producerOutcome {
+	t.Helper()
+	select {
+	case outcome := <-ticket.ackCh:
+		if outcome == nil {
+			t.Fatal("ticket resolved without an outcome")
+		}
+		return outcome
+	default:
+		t.Fatal("ticket was unresolved after flush")
+		return nil
+	}
+}
+
+func appendAck(start, end uint64) *AppendAck {
+	return &AppendAck{
+		Start: StreamPosition{SeqNum: start},
+		End:   StreamPosition{SeqNum: end},
+		Tail:  StreamPosition{SeqNum: end},
+	}
+}
+
+func TestProducer_FlushWaitsForCoveredBatches(t *testing.T) {
+	ctx := context.Background()
+	batcher := NewBatcher(ctx, &BatchingOptions{
+		MaxRecords:    2,
+		Linger:        time.Hour,
+		ChannelBuffer: 10,
+	})
+	session := newControlledAppendSession()
+	producer := newProducerWithSession(ctx, batcher, session)
+
+	tickets := []*RecordSubmitTicket{
+		submitRecord(t, producer, "a"),
+		submitRecord(t, producer, "b"),
+		submitRecord(t, producer, "c"),
+	}
+	flushDone := startFlush(producer, ctx)
+
+	first := nextAppendCall(t, session)
+	if len(first.input.Records) != 2 {
+		t.Fatalf("first batch has %d records, want 2", len(first.input.Records))
+	}
+	first.accept()
+	second := nextAppendCall(t, session)
+	if len(second.input.Records) != 1 {
+		t.Fatalf("partial batch has %d records, want 1", len(second.input.Records))
+	}
+	second.accept()
+
+	firstAck := appendAck(41, 43)
+	first.resolve(firstAck, nil)
+	requireFlushPending(t, flushDone)
+	secondAck := appendAck(43, 44)
+	second.resolve(secondAck, nil)
+	if err := waitFlush(t, flushDone); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	for i, ticket := range tickets {
+		outcome := readyOutcome(t, ticket)
+		if outcome.err != nil || outcome.indexedAck.SeqNum() != uint64(41+i) {
+			t.Fatalf("ticket %d outcome: %+v", i, outcome)
+		}
+		wantBatch := firstAck
+		if i == 2 {
+			wantBatch = secondAck
+		}
+		if outcome.indexedAck.BatchAppendAck() != wantBatch {
+			t.Fatalf("ticket %d references the wrong batch ack", i)
+		}
+	}
+
+	if err := producer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestProducer_FlushBoundaryIsReusable(t *testing.T) {
+	ctx := context.Background()
+	matchSeqNum := uint64(0)
+	batcher := NewBatcher(ctx, &BatchingOptions{
+		MaxRecords:    100,
+		Linger:        time.Hour,
+		ChannelBuffer: 10,
+		MatchSeqNum:   &matchSeqNum,
+	})
+	session := newControlledAppendSession()
+	producer := newProducerWithSession(ctx, batcher, session)
+
+	if err := waitFlush(t, startFlush(producer, ctx)); err != nil {
+		t.Fatalf("empty flush: %v", err)
+	}
+	select {
+	case call := <-session.calls:
+		t.Fatalf("empty flush appended: %+v", call.input)
+	default:
+	}
+
+	firstTicket := submitRecord(t, producer, "first")
+	firstFlush := startFlush(producer, ctx)
+	firstCall := nextAppendCall(t, session)
+	if firstCall.input.MatchSeqNum == nil || *firstCall.input.MatchSeqNum != 0 {
+		t.Fatalf("first match seq num: %v", firstCall.input.MatchSeqNum)
+	}
+	firstCall.accept()
+
+	secondTicket := submitRecord(t, producer, "second")
+	batcher.Flush()
+	firstCall.resolve(appendAck(0, 1), nil)
+
+	var secondCall *controlledAppendCall
+	select {
+	case err := <-firstFlush:
+		if err != nil {
+			t.Fatalf("first flush: %v", err)
+		}
+	case secondCall = <-session.calls:
+		secondCall.accept()
+		if err := waitFlush(t, firstFlush); err != nil {
+			t.Fatalf("first flush waited for later work: %v", err)
+		}
+	case <-time.After(flushTestTimeout):
+		t.Fatal("first flush timed out")
+	}
+
+	if outcome := readyOutcome(t, firstTicket); outcome.err != nil {
+		t.Fatalf("first ticket: %v", outcome.err)
+	}
+	select {
+	case outcome := <-secondTicket.ackCh:
+		t.Fatalf("first flush covered the later ticket: %+v", outcome)
+	default:
+	}
+
+	secondFlush := startFlush(producer, ctx)
+	if secondCall == nil {
+		secondCall = nextAppendCall(t, session)
+		secondCall.accept()
+	}
+	if secondCall.input.MatchSeqNum == nil || *secondCall.input.MatchSeqNum != 1 {
+		t.Fatalf("second match seq num: %v", secondCall.input.MatchSeqNum)
+	}
+	secondCall.resolve(appendAck(1, 2), nil)
+	if err := waitFlush(t, secondFlush); err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if outcome := readyOutcome(t, secondTicket); outcome.err != nil {
+		t.Fatalf("second ticket: %v", outcome.err)
+	}
+
+	if err := producer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestProducer_FlushPropagatesTerminalAckError(t *testing.T) {
+	ctx := context.Background()
+	batcher := NewBatcher(ctx, &BatchingOptions{
+		MaxRecords:    1,
+		Linger:        time.Hour,
+		ChannelBuffer: 10,
+	})
+	session := newControlledAppendSession()
+	producer := newProducerWithSession(ctx, batcher, session)
+	tickets := []*RecordSubmitTicket{
+		submitRecord(t, producer, "fails"),
+		submitRecord(t, producer, "covered"),
+	}
+
+	flushDone := startFlush(producer, ctx)
+	first := nextAppendCall(t, session)
+	first.accept()
+	second := nextAppendCall(t, session)
+	second.accept()
+	conditionErr := newSeqNumMismatchError(http.StatusPreconditionFailed, 0)
+	first.resolve(nil, conditionErr)
+
+	if err := waitFlush(t, flushDone); err != conditionErr {
+		t.Fatalf("flush error: %v", err)
+	}
+	for i, ticket := range tickets {
+		if err := readyOutcome(t, ticket).err; err != conditionErr {
+			t.Fatalf("ticket %d error: %v", i, err)
+		}
+	}
+	if err := waitFlush(t, startFlush(producer, ctx)); err != conditionErr {
+		t.Fatalf("repeated flush error: %v", err)
+	}
+	if _, err := producer.Submit(AppendRecord{}); err != conditionErr {
+		t.Fatalf("submit after failure: %v", err)
+	}
+	if err := producer.Close(); err != conditionErr {
+		t.Fatalf("close error: %v", err)
+	}
+}
+
+func TestProducer_SynchronousFailureReleasesCoveredTickets(t *testing.T) {
+	ctx := context.Background()
+	terminalErr := errors.New("acceptance failed")
+	batcher := NewBatcher(ctx, &BatchingOptions{
+		MaxRecords:    1,
+		Linger:        time.Hour,
+		ChannelBuffer: 10,
+	})
+	session := newControlledAppendSession()
+	producer := newProducerWithSession(ctx, batcher, session)
+	tickets := []*RecordSubmitTicket{
+		submitRecord(t, producer, "ack pending"),
+		submitRecord(t, producer, "acceptance fails"),
+	}
+
+	flushDone := startFlush(producer, ctx)
+	first := nextAppendCall(t, session)
+	first.accept()
+	second := nextAppendCall(t, session)
+	second.reject(terminalErr)
+
+	if err := waitFlush(t, flushDone); err != terminalErr {
+		t.Fatalf("flush error: %v", err)
+	}
+	for i, ticket := range tickets {
+		if err := readyOutcome(t, ticket).err; err != terminalErr {
+			t.Fatalf("ticket %d error: %v", i, err)
+		}
+	}
+	if err := producer.Close(); err != terminalErr {
+		t.Fatalf("close error: %v", err)
+	}
+}
+
+func TestProducer_FlushCancellationWhileBackpressured(t *testing.T) {
+	ctx := context.Background()
+	batcher := NewBatcher(ctx, &BatchingOptions{
+		MaxRecords:    1,
+		Linger:        time.Hour,
+		ChannelBuffer: 1,
+	})
+	session := newControlledAppendSession()
+	producer := newProducerWithSession(ctx, batcher, session)
+	tickets := []*RecordSubmitTicket{
+		submitRecord(t, producer, "consumer blocked"),
+		submitRecord(t, producer, "channel full"),
+	}
+	first := nextAppendCall(t, session)
+
+	flushCtx, cancelFlush := context.WithCancel(ctx)
+	flushDone := startFlush(producer, flushCtx)
+	deadline := time.Now().Add(flushTestTimeout)
+	for batcher.mu.TryLock() {
+		batcher.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("barrier did not reach backpressure")
+		}
+		runtime.Gosched()
+	}
+	cancelFlush()
+	if err := waitFlush(t, flushDone); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled flush: %v", err)
+	}
+
+	first.accept()
+	first.resolve(appendAck(0, 1), nil)
+	second := nextAppendCall(t, session)
+	second.accept()
+	second.resolve(appendAck(1, 2), nil)
+	if err := waitFlush(t, startFlush(producer, ctx)); err != nil {
+		t.Fatalf("flush after backpressure: %v", err)
+	}
+	for i, ticket := range tickets {
+		outcome := readyOutcome(t, ticket)
+		if outcome.err != nil {
+			t.Fatalf("ticket %d outcome: %+v", i, outcome)
+		}
+	}
+	if err := producer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `Producer.Flush(ctx)` as a durable, reusable boundary
- order flushes atomically with record submission
- return the same terminal append error to covered tickets and later producer operations
- clarify that `Batcher.Flush()` emits without waiting for durability

## Tests

Five deterministic tests cover:

- partial and multi-batch durability
- empty, reusable boundaries and sequence progression
- acknowledgement and acceptance failures
- cancellation while ordering is backpressured

Validated with `task test`, `task lint`, and repeated focused race runs.

Implements the Go SDK portion of https://github.com/s2-streamstore/s2/issues/666.
Go counterpart to https://github.com/s2-streamstore/s2/pull/698.