### PR TITLE
perf: flatten append protobuf allocations

### DIFF
--- a/s2/append.go
+++ b/s2/append.go
@@ -418,20 +418,30 @@ func convertAppendInputToProto(input *AppendInput) *pb.AppendInput {
 		return nil
 	}
 
+	headerCount := 0
+	for _, record := range input.Records {
+		headerCount += len(record.Headers)
+	}
+
+	recordValues := make([]pb.AppendRecord, len(input.Records))
 	pbRecords := make([]*pb.AppendRecord, len(input.Records))
+	headerValues := make([]pb.Header, headerCount)
+	headerPtrs := make([]*pb.Header, headerCount)
+	headerOffset := 0
 	for i, record := range input.Records {
-		pbRecord := &pb.AppendRecord{
-			Timestamp: record.Timestamp,
-		}
+		pbRecord := &recordValues[i]
+		pbRecord.Timestamp = record.Timestamp
 
 		if len(record.Headers) > 0 {
-			pbRecord.Headers = make([]*pb.Header, len(record.Headers))
+			end := headerOffset + len(record.Headers)
+			pbRecord.Headers = headerPtrs[headerOffset:end:end]
 			for j, header := range record.Headers {
-				pbRecord.Headers[j] = &pb.Header{
-					Name:  header.Name,
-					Value: header.Value,
-				}
+				pbHeader := &headerValues[headerOffset+j]
+				pbHeader.Name = header.Name
+				pbHeader.Value = header.Value
+				pbRecord.Headers[j] = pbHeader
 			}
+			headerOffset = end
 		}
 
 		if len(record.Body) > 0 {

--- a/s2/append_proto_test.go
+++ b/s2/append_proto_test.go
@@ -1,0 +1,87 @@
+package s2
+
+import (
+	"bytes"
+	"testing"
+
+	pb "github.com/s2-streamstore/s2-sdk-go/generated"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestConvertAppendInputToProto(t *testing.T) {
+	cases := []struct {
+		name  string
+		input *AppendInput
+		want  *pb.AppendInput
+	}{
+		{name: "nil"},
+		{name: "empty", input: &AppendInput{}, want: &pb.AppendInput{}},
+		{
+			name: "mixed records",
+			input: &AppendInput{
+				MatchSeqNum:  Uint64(0),
+				FencingToken: String(""),
+				Records: []AppendRecord{
+					{Timestamp: Uint64(0), Headers: []Header{{Value: []byte("fence")}}, Body: []byte("token")},
+					{Body: []byte{}, Headers: []Header{}},
+					{Timestamp: Uint64(123), Headers: []Header{
+						{Name: []byte("first"), Value: []byte{0, 255}},
+						{Name: []byte("second"), Value: []byte{}},
+					}, Body: []byte{128, 0, 255}},
+					{},
+				},
+			},
+			want: &pb.AppendInput{
+				MatchSeqNum:  Uint64(0),
+				FencingToken: String(""),
+				Records: []*pb.AppendRecord{
+					{Timestamp: Uint64(0), Headers: []*pb.Header{{Value: []byte("fence")}}, Body: []byte("token")},
+					{},
+					{Timestamp: Uint64(123), Headers: []*pb.Header{
+						{Name: []byte("first"), Value: []byte{0, 255}},
+						{Name: []byte("second"), Value: []byte{}},
+					}, Body: []byte{128, 0, 255}},
+					{},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertAppendInputToProto(tc.input)
+			if !proto.Equal(got, tc.want) {
+				t.Fatalf("converted input = %v, want %v", got, tc.want)
+			}
+			encoded, err := proto.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := proto.Marshal(tc.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(encoded, want) {
+				t.Fatalf("encoded input = %x, want %x", encoded, want)
+			}
+		})
+	}
+}
+
+func TestConvertAppendInputToProtoHeaderIndependence(t *testing.T) {
+	input := &AppendInput{Records: []AppendRecord{
+		{Headers: []Header{{Name: []byte("first")}}},
+		{},
+		{Headers: []Header{{Name: []byte("second")}, {Name: []byte("third")}}},
+	}}
+	got := convertAppendInputToProto(input)
+	got.Records[0].Headers[0].Name = []byte("changed")
+	got.Records[0].Headers = append(got.Records[0].Headers, &pb.Header{Name: []byte("extra")})
+	if got.Records[1].Headers != nil {
+		t.Fatal("record without headers gained headers")
+	}
+	if len(got.Records[2].Headers) != 2 ||
+		string(got.Records[2].Headers[0].Name) != "second" ||
+		string(got.Records[2].Headers[1].Name) != "third" {
+		t.Fatal("changing one record's headers changed another record")
+	}
+}


### PR DESCRIPTION
Append conversion allocates a protobuf object for every record and header. Store these objects in contiguous arrays per batch, with shared header-pointer storage and capped per-record slice capacity.

Adds tests for wire compatibility, optional fields, and independent header slices.

Validation: `go test ./...` passed with integration credentials unset, along with targeted race tests for append conversion, protobuf framing, and transport appends. `golangci-lint run ./...` also passed.
