### PR TITLE
test: run the public SDK through a proxy to Lite (1/6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: none
     name: CI
-    needs: [examples, test, s2-integration, s2-lite-integration, golangci-lint, bento-integration]
+    needs: [examples, test, s2-integration, s2-lite-integration, fault-tests, golangci-lint, bento-integration]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -107,6 +107,37 @@ jobs:
   build-s2-lite:
     name: Build S2-lite
     uses: s2-streamstore/s2/.github/workflows/build-s2-lite.yml@main
+
+  fault-tests:
+    name: SDK correctness
+    needs: build-s2-lite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure fault harness
+        run: |
+          {
+            echo "S2_LITE_BIN=$RUNNER_TEMP/s2-lite/server"
+            echo "S2_FAULT_OUTPUT=$RUNNER_TEMP/sdk-faults"
+          } >> "$GITHUB_ENV"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.23"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: server-binary
+          path: ${{ runner.temp }}/s2-lite
+      - name: Test Lite fault harness
+        run: |
+          chmod +x "$S2_LITE_BIN"
+          go test -race -count=1 -timeout=3m ./internal/faulttest
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: sdk-faults
+          path: |
+            ${{ runner.temp }}/sdk-faults
 
   s2-lite-integration:
     name: S2-lite Integration

--- a/internal/faulttest/README.md
+++ b/internal/faulttest/README.md
@@ -1,0 +1,15 @@
+The harness drives the public Go SDK through an HTTP/2 proxy to real S2 Lite.
+Each test owns its basin and stream. Lite uses a temporary disk directory; the
+managed process is killed on cleanup, with files retained on failure.
+
+Set `S2_LITE_BIN` to a standalone Lite server or use the S2 CLI:
+
+```sh
+export S2_LITE_BIN=s2
+export S2_LITE_ARGS='["lite"]'
+go test -race ./internal/faulttest
+```
+
+Tests requiring a binary skip when it is unset. CI supplies the required
+binaries and runs the race detector. `S2_FAULT_OUTPUT` chooses the
+artifact parent directory; successful runs clean up their files.

--- a/internal/faulttest/lite_test.go
+++ b/internal/faulttest/lite_test.go
@@ -1,0 +1,183 @@
+package faulttest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/s2-streamstore/s2-sdk-go/s2"
+)
+
+type liteProcess struct {
+	mu         sync.Mutex
+	binary     string
+	args       []string
+	root       string
+	port       string
+	endpoint   string
+	cmd        *exec.Cmd
+	generation int
+}
+
+func newLite(t testing.TB) *liteProcess {
+	t.Helper()
+	binary := os.Getenv("S2_LITE_BIN")
+	if binary == "" {
+		t.Skip("set S2_LITE_BIN to a server binary (or s2 with S2_LITE_ARGS='[\"lite\"]')")
+	}
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lite := &liteProcess{binary: path, root: resultDir(t)}
+	if raw := os.Getenv("S2_LITE_ARGS"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &lite.args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lite.port = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	lite.endpoint = "http://127.0.0.1:" + lite.port
+	_ = listener.Close()
+	t.Cleanup(func() { _ = lite.kill() })
+	if err := lite.start(); err != nil {
+		t.Fatal(err)
+	}
+	return lite
+}
+
+func (p *liteProcess) start() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cmd != nil {
+		return nil
+	}
+	p.generation++
+	logPath := filepath.Join(p.root, fmt.Sprintf("server-%d.log", p.generation))
+	log, err := os.Create(logPath)
+	if err != nil {
+		return err
+	}
+	defer log.Close()
+	args := append(append([]string(nil), p.args...), "--port", p.port, "--local-root", filepath.Join(p.root, "storage"))
+	cmd := exec.Command(p.binary, args...)
+	cmd.Stdout, cmd.Stderr = log, log
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, "S2LITE_INIT_FILE=") && !strings.HasPrefix(entry, "RUST_LOG=") {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Env = append(cmd.Env, "RUST_LOG=error")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	p.cmd = cmd
+	client := &http.Client{Timeout: 300 * time.Millisecond}
+	defer client.CloseIdleConnections()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		response, err := client.Get(p.endpoint + "/health")
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			p.cmd = nil
+			data, _ := os.ReadFile(logPath)
+			return fmt.Errorf("Lite did not become ready: %s", data)
+		}
+	}
+}
+
+func (p *liteProcess) kill() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cmd == nil {
+		return nil
+	}
+	if err := p.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	_ = p.cmd.Wait()
+	p.cmd = nil
+	return nil
+}
+
+func provision(t *testing.T, endpoint string) (string, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client := testClient(endpoint, s2.CompressionNone)
+	basin := s2.BasinName(fmt.Sprintf("sdk-fault-%d", time.Now().UnixNano()))
+	if _, err := client.Basins.Create(ctx, s2.CreateBasinArgs{Basin: basin}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = client.Basins.Delete(ctx, basin)
+	})
+	name := s2.StreamName("history")
+	if _, err := client.Basin(string(basin)).Streams.Create(ctx, s2.CreateStreamArgs{Stream: name}); err != nil {
+		t.Fatal(err)
+	}
+	return string(basin), string(name)
+}
+
+func testClient(endpoint string, compression s2.CompressionType) *s2.Client {
+	token := os.Getenv("S2_FAULT_ACCESS_TOKEN")
+	if token == "" {
+		token = "test"
+	}
+	return s2.New(token, &s2.ClientOptions{
+		BaseURL: endpoint, MakeBasinBaseURL: func(string) string { return endpoint },
+		Compression: compression, RequestTimeout: 3 * time.Second,
+		RetryConfig: &s2.RetryConfig{MaxAttempts: 3, MinBaseDelay: time.Millisecond, MaxBaseDelay: time.Millisecond, AppendRetryPolicy: s2.AppendRetryPolicyNoSideEffects},
+	})
+}
+
+func resultDir(t testing.TB) string {
+	t.Helper()
+	root := os.Getenv("S2_FAULT_OUTPUT")
+	if root == "" {
+		root = os.TempDir()
+	}
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(root, strings.ReplaceAll(t.Name(), "/", "-")+"-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("artifacts: %s", dir)
+		} else {
+			_ = os.RemoveAll(dir)
+		}
+	})
+	return dir
+}

--- a/internal/faulttest/lite_test.go
+++ b/internal/faulttest/lite_test.go
@@ -140,7 +140,7 @@ func provision(t *testing.T, endpoint string) (string, string) {
 		defer cancel()
 		_ = client.Basins.Delete(ctx, basin)
 	})
-	name := s2.StreamName("history")
+	name := s2.StreamName("history/with spaces%2F?#")
 	if _, err := client.Basin(string(basin)).Streams.Create(ctx, s2.CreateStreamArgs{Stream: name}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/faulttest/proxy_smoke_test.go
+++ b/internal/faulttest/proxy_smoke_test.go
@@ -1,0 +1,35 @@
+package faulttest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/s2-streamstore/s2-sdk-go/s2"
+)
+
+func TestLiteProxy(t *testing.T) {
+	lite := newLite(t)
+	basin, name := provision(t, lite.endpoint)
+	proxy := newFaultProxy(t, lite.endpoint, 1)
+	stream := testClient(fmt.Sprintf("%s/op/0/v1", proxy.endpoint), s2.CompressionNone).Basin(basin).Stream(s2.StreamName(name))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	body := []byte("through-proxy")
+	ack, err := stream.Append(ctx, &s2.AppendInput{Records: []s2.AppendRecord{{Body: body}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ack.Start.SeqNum != 0 || ack.End.SeqNum != 1 {
+		t.Fatalf("unexpected ack: %+v", ack)
+	}
+	batch, err := stream.Read(ctx, &s2.ReadOptions{SeqNum: s2.Uint64(0)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Records) != 1 || batch.Records[0].SeqNum != 0 || !bytes.Equal(batch.Records[0].Body, body) {
+		t.Fatalf("unexpected records: %+v", batch.Records)
+	}
+}

--- a/internal/faulttest/proxy_test.go
+++ b/internal/faulttest/proxy_test.go
@@ -62,7 +62,7 @@ func newFaultProxy(t *testing.T, endpoint string, operations int) *faultProxy {
 }
 
 func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
-	parts := strings.SplitN(strings.TrimPrefix(req.URL.Path, "/op/"), "/", 2)
+	parts := strings.SplitN(strings.TrimPrefix(req.URL.EscapedPath(), "/op/"), "/", 2)
 	id, err := strconv.Atoi(parts[0])
 	if err != nil || len(parts) != 2 || id < 0 || id >= p.ops {
 		http.Error(w, "invalid operation", http.StatusBadRequest)
@@ -70,7 +70,8 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	request := req.Clone(req.Context())
 	request.URL.Scheme, request.URL.Host = p.upstream.Scheme, p.upstream.Host
-	request.URL.Path = "/" + parts[1]
+	request.URL.RawPath = "/" + parts[1]
+	request.URL.Path, _ = url.PathUnescape(request.URL.RawPath)
 	request.Host = p.upstream.Host
 	request.RequestURI = ""
 	response, err := p.transport.RoundTrip(request)

--- a/internal/faulttest/proxy_test.go
+++ b/internal/faulttest/proxy_test.go
@@ -1,0 +1,99 @@
+package faulttest
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+type faultProxy struct {
+	endpoint  string
+	upstream  *url.URL
+	transport *http2.Transport
+	ops       int
+}
+
+func newFaultProxy(t *testing.T, endpoint string, operations int) *faultProxy {
+	t.Helper()
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &faultProxy{upstream: u, ops: operations}
+	p.transport = &http2.Transport{AllowHTTP: true, DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+		if u.Scheme == "https" {
+			return (&tls.Dialer{Config: cfg}).DialContext(ctx, network, addr)
+		}
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
+	}}
+	server := httptest.NewUnstartedServer(h2c.NewHandler(http.HandlerFunc(p.serveHTTP), &http2.Server{}))
+	var conns []net.Conn
+	var connMu sync.Mutex
+	server.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connMu.Lock()
+			conns = append(conns, conn)
+			connMu.Unlock()
+		}
+	}
+	server.Start()
+	p.endpoint = server.URL
+	t.Cleanup(func() {
+		server.Close()
+		connMu.Lock()
+		defer connMu.Unlock()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+		p.transport.CloseIdleConnections()
+	})
+	return p
+}
+
+func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
+	parts := strings.SplitN(strings.TrimPrefix(req.URL.Path, "/op/"), "/", 2)
+	id, err := strconv.Atoi(parts[0])
+	if err != nil || len(parts) != 2 || id < 0 || id >= p.ops {
+		http.Error(w, "invalid operation", http.StatusBadRequest)
+		return
+	}
+	request := req.Clone(req.Context())
+	request.URL.Scheme, request.URL.Host = p.upstream.Scheme, p.upstream.Host
+	request.URL.Path = "/" + parts[1]
+	request.Host = p.upstream.Host
+	request.RequestURI = ""
+	response, err := p.transport.RoundTrip(request)
+	if err != nil {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	defer response.Body.Close()
+	for name, values := range response.Header {
+		w.Header()[name] = values
+	}
+	w.Header().Del("Content-Length")
+	w.WriteHeader(response.StatusCode)
+	w.(http.Flusher).Flush()
+	_, _ = io.Copy(flushWriter{w}, response.Body)
+}
+
+type flushWriter struct {
+	http.ResponseWriter
+}
+
+func (w flushWriter) Write(data []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(data)
+	w.ResponseWriter.(http.Flusher).Flush()
+	return n, err
+}


### PR DESCRIPTION
Start a managed, disk-backed Lite process and route public SDK requests through an HTTP/2 forwarding proxy. A smoke test appends and reads a record through that path. Tests own their basins, processes, and temporary storage; CI supplies the Lite binary from this first layer.

Review `lite_test.go` for process lifecycle and cleanup, `proxy_test.go` for forwarding, and `proxy_smoke_test.go` for the SDK round trip. Lite serves every backend response.

Validation: Harness race tests against real Lite, harness lint, and workflow validation passed.

Part 1/6 replacing #375. Base: `main`. Next: #378.

Ready to review and merge first.
