### PR TITLE
test: replay append faults against Lite (2/6)

### DIFF
--- a/internal/faulttest/README.md
+++ b/internal/faulttest/README.md
@@ -10,6 +10,18 @@ export S2_LITE_ARGS='["lite"]'
 go test -race ./internal/faulttest
 ```
 
+Replay tests check exact retry counts, ACK ranges, payloads, and tail positions
+against a model derived from the trace. They use fixed client timestamps and
+one append batch per session. The proxy rejects a request before forwarding it
+or substitutes an error after observing Lite's commit ACK. Negative controls
+corrupt ACKs and payloads to verify the assertions reject them.
+
+Failures retain `trace.json` and `wire.json` in the logged artifact directory:
+
+```sh
+S2_FAULT_TRACE=/path/to/trace.json go test ./internal/faulttest -run '^TestReplay$' -count=1
+```
+
 Tests requiring a binary skip when it is unset. CI supplies the required
 binaries and runs the race detector. `S2_FAULT_OUTPUT` chooses the
 artifact parent directory; successful runs clean up their files.

--- a/internal/faulttest/harness_test.go
+++ b/internal/faulttest/harness_test.go
@@ -1,0 +1,51 @@
+package faulttest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/s2-streamstore/s2-sdk-go/s2"
+)
+
+type harness struct {
+	script      trace
+	proxy       *faultProxy
+	basin, name string
+	dir         string
+}
+
+func newHarness(t *testing.T, endpoint string, script trace) *harness {
+	t.Helper()
+	basin, name := provision(t, endpoint)
+	plans := make([]faultPlan, len(script.Batches)+1)
+	for i, batch := range script.Batches {
+		plans[i].Fault = batch.Fault
+	}
+	p := newFaultProxy(t, endpoint, plans)
+	dir := resultDir(t)
+	data, _ := json.MarshalIndent(script, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "trace.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		wire, _ := json.MarshalIndent(p.wire, "", "  ")
+		_ = os.WriteFile(filepath.Join(dir, "wire.json"), wire, 0600)
+	})
+	return &harness{script: script, proxy: p, basin: basin, name: name, dir: dir}
+}
+
+func (h *harness) stream(id int) *s2.StreamClient {
+	endpoint := fmt.Sprintf("%s/op/%d/v1", h.proxy.endpoint, id)
+	client := s2.New("test", &s2.ClientOptions{
+		BaseURL: endpoint, MakeBasinBaseURL: func(string) string { return endpoint },
+		RequestTimeout: 3 * time.Second,
+		RetryConfig:    &s2.RetryConfig{MaxAttempts: 3, MinBaseDelay: time.Millisecond, MaxBaseDelay: time.Millisecond, AppendRetryPolicy: h.script.Policy},
+	})
+	return client.Basin(h.basin).Stream(s2.StreamName(h.name))
+}

--- a/internal/faulttest/proxy_smoke_test.go
+++ b/internal/faulttest/proxy_smoke_test.go
@@ -13,7 +13,7 @@ import (
 func TestLiteProxy(t *testing.T) {
 	lite := newLite(t)
 	basin, name := provision(t, lite.endpoint)
-	proxy := newFaultProxy(t, lite.endpoint, 1)
+	proxy := newFaultProxy(t, lite.endpoint, make([]faultPlan, 1))
 	stream := testClient(fmt.Sprintf("%s/op/0/v1", proxy.endpoint), s2.CompressionNone).Basin(basin).Stream(s2.StreamName(name))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/faulttest/proxy_test.go
+++ b/internal/faulttest/proxy_test.go
@@ -3,6 +3,8 @@ package faulttest
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -13,24 +15,37 @@ import (
 	"sync"
 	"testing"
 
+	pb "github.com/s2-streamstore/s2-sdk-go/generated"
+	"github.com/s2-streamstore/s2-sdk-go/internal/framing"
+	"github.com/s2-streamstore/s2-sdk-go/s2"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"google.golang.org/protobuf/proto"
 )
+
+type faultPlan struct {
+	Fault string
+}
 
 type faultProxy struct {
 	endpoint  string
 	upstream  *url.URL
 	transport *http2.Transport
-	ops       int
+	mu        sync.Mutex
+	attempts  map[int]int
+	fired     map[int]bool
+	wire      []string
+	ops       []faultPlan
+	corrupt   func(proto.Message)
 }
 
-func newFaultProxy(t *testing.T, endpoint string, operations int) *faultProxy {
+func newFaultProxy(t *testing.T, endpoint string, plans []faultPlan) *faultProxy {
 	t.Helper()
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		t.Fatal(err)
 	}
-	p := &faultProxy{upstream: u, ops: operations}
+	p := &faultProxy{upstream: u, ops: plans, attempts: make(map[int]int), fired: make(map[int]bool)}
 	p.transport = &http2.Transport{AllowHTTP: true, DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
 		if u.Scheme == "https" {
 			return (&tls.Dialer{Config: cfg}).DialContext(ctx, network, addr)
@@ -64,8 +79,23 @@ func newFaultProxy(t *testing.T, endpoint string, operations int) *faultProxy {
 func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	parts := strings.SplitN(strings.TrimPrefix(req.URL.EscapedPath(), "/op/"), "/", 2)
 	id, err := strconv.Atoi(parts[0])
-	if err != nil || len(parts) != 2 || id < 0 || id >= p.ops {
+	if err != nil || len(parts) != 2 || id < 0 || id >= len(p.ops) {
 		http.Error(w, "invalid operation", http.StatusBadRequest)
+		return
+	}
+	p.mu.Lock()
+	p.attempts[id]++
+	attempt := p.attempts[id]
+	p.wire = append(p.wire, fmt.Sprintf("op=%d attempt=%d %s %s", id, attempt, req.Method, req.URL.RawQuery))
+	p.mu.Unlock()
+	plan := p.ops[id]
+	fault := plan.Fault
+	if attempt != 1 {
+		fault = ""
+	}
+	if fault == beforeCommit {
+		p.injected(id, fault)
+		p.replyError(w, false, http.StatusTooManyRequests, "rate_limited")
 		return
 	}
 	request := req.Clone(req.Context())
@@ -76,17 +106,95 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	request.RequestURI = ""
 	response, err := p.transport.RoundTrip(request)
 	if err != nil {
-		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+		p.replyError(w, false, http.StatusServiceUnavailable, "unavailable")
 		return
 	}
 	defer response.Body.Close()
+	streaming := req.Header.Get("Content-Type") == "s2s/proto"
+	appendRequest := req.Method == http.MethodPost
+	if response.StatusCode == http.StatusOK && appendRequest && fault == afterCommit {
+		var data []byte
+		if streaming {
+			frame, readErr := framing.NewFrameReader(response.Body).ReadFrame()
+			if readErr != nil || frame.Terminal {
+				panic(http.ErrAbortHandler)
+			}
+			data, err = frame.DecompressedBody()
+		} else {
+			data, err = io.ReadAll(response.Body)
+		}
+		var ack pb.AppendAck
+		if err != nil || proto.Unmarshal(data, &ack) != nil || ack.Start == nil || ack.End == nil || ack.Tail == nil {
+			panic(http.ErrAbortHandler)
+		}
+		p.injected(id, fault)
+		p.replyError(w, streaming, http.StatusServiceUnavailable, "unavailable")
+		return
+	}
 	for name, values := range response.Header {
 		w.Header()[name] = values
 	}
 	w.Header().Del("Content-Length")
 	w.WriteHeader(response.StatusCode)
 	w.(http.Flusher).Flush()
+	if response.StatusCode != http.StatusOK || (fault == "" && p.corrupt == nil) {
+		_, _ = io.Copy(flushWriter{w}, response.Body)
+		return
+	}
+	if !streaming {
+		data, err := io.ReadAll(response.Body)
+		if err != nil {
+			panic(http.ErrAbortHandler)
+		}
+		if p.corrupt != nil {
+			if appendRequest {
+				data = p.rewrite(data, &pb.AppendAck{})
+			} else if !strings.HasSuffix(req.URL.Path, "/tail") {
+				data = p.rewrite(data, &pb.ReadBatch{})
+			}
+		}
+		_, _ = (flushWriter{w}).Write(data)
+		return
+	}
 	_, _ = io.Copy(flushWriter{w}, response.Body)
+}
+
+func (p *faultProxy) rewrite(data []byte, message proto.Message) []byte {
+	if proto.Unmarshal(data, message) != nil {
+		panic(http.ErrAbortHandler)
+	}
+	p.corrupt(message)
+	data, err := proto.Marshal(message)
+	if err != nil {
+		panic(http.ErrAbortHandler)
+	}
+	return data
+}
+
+func (p *faultProxy) replyError(w http.ResponseWriter, streaming bool, status int, code string) {
+	data, _ := json.Marshal(s2.ErrorInfo{Code: code, Message: code})
+	if streaming {
+		p.writeFrame(w, data, true, status, false)
+	} else {
+		w.WriteHeader(status)
+		_, _ = (flushWriter{w}).Write(data)
+	}
+}
+
+func (p *faultProxy) writeFrame(w http.ResponseWriter, data []byte, terminal bool, status int, reconnect bool) bool {
+	wire := framing.CreateFrameWithStatus(data, terminal, framing.CompressionNone, status)
+	if reconnect {
+		wire[3] |= 0x10
+	}
+	_, err := (flushWriter{w}).Write(wire)
+	return err == nil
+}
+
+func (p *faultProxy) injected(id int, fault string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.fired[id] = true
+	p.wire = append(p.wire, fmt.Sprintf("op=%d injected=%s", id, fault))
 }
 
 type flushWriter struct {

--- a/internal/faulttest/replay_test.go
+++ b/internal/faulttest/replay_test.go
@@ -1,0 +1,306 @@
+package faulttest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/s2-streamstore/s2-sdk-go/generated"
+	"github.com/s2-streamstore/s2-sdk-go/s2"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	beforeCommit = "before_commit"
+	afterCommit  = "after_commit"
+)
+
+type batch struct {
+	Records []s2.AppendRecord `json:"records"`
+	Fault   string            `json:"fault,omitempty"`
+	Match   bool              `json:"match,omitempty"`
+}
+
+type trace struct {
+	Session bool                 `json:"session"`
+	Policy  s2.AppendRetryPolicy `json:"policy"`
+	Batches []batch              `json:"batches"`
+}
+
+func TestReplay(t *testing.T) {
+	lite := newLite(t)
+	if path := os.Getenv("S2_FAULT_TRACE"); path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var script trace
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&script); err != nil {
+			t.Fatal(err)
+		}
+		checkReplay(t, lite.endpoint, script)
+		return
+	}
+	for mode := byte(0); mode < 4; mode++ {
+		for fault := byte(0); fault < 6; fault++ {
+			t.Run(fmt.Sprintf("%d/%d", mode, fault), func(t *testing.T) {
+				checkReplay(t, lite.endpoint, makeTrace([]byte{mode, fault, 3, 1, 255, 192}))
+			})
+		}
+	}
+}
+
+func TestReplayRejectsCorruption(t *testing.T) {
+	lite := newLite(t)
+	for _, target := range []string{"ack", "records"} {
+		t.Run(target, func(t *testing.T) {
+			h := newHarness(t, lite.endpoint, makeTrace([]byte{0, 0}))
+			h.proxy.mu.Lock()
+			h.proxy.corrupt = func(message proto.Message) {
+				switch m := message.(type) {
+				case *pb.AppendAck:
+					if target == "ack" {
+						m.End.SeqNum++
+					}
+				case *pb.ReadBatch:
+					if target == "records" {
+						m.Records[0].Body = []byte("corrupt")
+					}
+				}
+			}
+			h.proxy.mu.Unlock()
+			if err := h.replay(); err == nil || !strings.Contains(err.Error(), target) {
+				t.Fatalf("expected %s violation, got %v", target, err)
+			}
+		})
+	}
+}
+
+func TestReplayDeterministic(t *testing.T) {
+	lite := newLite(t)
+	var history []string
+	for range 2 {
+		h := newHarness(t, lite.endpoint, makeTrace([]byte{9, 4, 2, 5}))
+		if err := h.replay(); err != nil {
+			t.Fatal(err)
+		}
+		h.proxy.mu.Lock()
+		got := slices.Clone(h.proxy.wire)
+		h.proxy.mu.Unlock()
+		if history != nil && !slices.Equal(history, got) {
+			t.Fatalf("replay changed history: %v != %v", history, got)
+		}
+		history = got
+	}
+}
+
+func makeTrace(data []byte) trace {
+	script := trace{
+		Session: data[0]&1 != 0, Policy: s2.AppendRetryPolicyAll,
+	}
+	if data[0]&2 != 0 {
+		script.Policy = s2.AppendRetryPolicyNoSideEffects
+	}
+	for i, value := range data[1:] {
+		b := batch{Match: value&1 != 0}
+		if i == 0 {
+			b.Fault = []string{"", beforeCommit, afterCommit}[value/2%3]
+		}
+		for j := 0; j <= int(value)%3; j++ {
+			b.Records = append(b.Records, s2.AppendRecord{
+				Body:    bytes.Repeat([]byte{byte(i), byte(j), value}, 1+int(value)*2),
+				Headers: []s2.Header{{Name: []byte("id"), Value: []byte{byte(i), byte(j)}}},
+			})
+		}
+		script.Batches = append(script.Batches, b)
+	}
+	return script
+}
+
+func checkReplay(t *testing.T, endpoint string, script trace) {
+	t.Helper()
+	if err := script.validate(); err != nil {
+		t.Fatal(err)
+	}
+	h := newHarness(t, endpoint, script)
+	if err := h.replay(); err != nil {
+		h.proxy.mu.Lock()
+		defer h.proxy.mu.Unlock()
+		t.Fatalf("%v; artifacts: %s; history: %v", err, h.dir, h.proxy.wire)
+	}
+}
+
+func (s trace) validate() error {
+	if s.Policy != s2.AppendRetryPolicyAll && s.Policy != s2.AppendRetryPolicyNoSideEffects {
+		return fmt.Errorf("invalid retry policy %q", s.Policy)
+	}
+	if len(s.Batches) == 0 || len(s.Batches) > 32 {
+		return errors.New("invalid trace bounds")
+	}
+	var count int
+	var size uint64
+	for _, b := range s.Batches {
+		count += len(b.Records)
+		if len(b.Records) == 0 || len(b.Records) > 32 {
+			return errors.New("batch must contain 1–32 records")
+		}
+		if b.Fault != "" && b.Fault != beforeCommit && b.Fault != afterCommit {
+			return fmt.Errorf("unknown append fault %q", b.Fault)
+		}
+		for _, r := range b.Records {
+			size += recordBytes(s2.SequencedRecord{Body: r.Body, Headers: r.Headers})
+			if r.Timestamp != nil || len(r.Body) > 4096 {
+				return errors.New("records must omit timestamps and have bodies at most 4096 bytes")
+			}
+			for _, header := range r.Headers {
+				if len(header.Name) == 0 {
+					return errors.New("command records are not supported")
+				}
+			}
+		}
+	}
+	if count > 128 || size > 256*1024 {
+		return errors.New("trace exceeds 128 records or 256 KiB")
+	}
+	return nil
+}
+
+func (h *harness) replay() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var expected []s2.SequencedRecord
+	for i, b := range h.script.Batches {
+		stream := h.stream(i)
+		var session *s2.AppendSession
+		if h.script.Session {
+			var err error
+			session, err = stream.AppendSession(ctx, nil)
+			if err != nil {
+				return err
+			}
+			defer session.Close()
+		}
+		input := &s2.AppendInput{Records: slices.Clone(b.Records)}
+		for j := range input.Records {
+			input.Records[j].Timestamp = s2.Uint64(42)
+		}
+		start := uint64(len(expected))
+		if b.Match {
+			input.MatchSeqNum = &start
+		}
+		attempts, copies := 1, 1
+		wantError := b.Fault == afterCommit && (b.Match || h.script.Policy == s2.AppendRetryPolicyNoSideEffects)
+		if b.Fault == beforeCommit || (b.Fault == afterCommit && h.script.Policy == s2.AppendRetryPolicyAll) {
+			attempts = 2
+		}
+		if b.Fault == afterCommit && !wantError {
+			copies = 2
+		}
+		for range copies {
+			for _, r := range b.Records {
+				expected = append(expected, s2.SequencedRecord{SeqNum: uint64(len(expected)), Timestamp: 42, Body: r.Body, Headers: r.Headers})
+			}
+		}
+		ack, err := appendBatch(ctx, stream, session, input)
+		if ctx.Err() != nil || (err != nil) != wantError {
+			return fmt.Errorf("batch %d: expected error=%t, got %v", i, wantError, err)
+		}
+		if wantError {
+			status := http.StatusServiceUnavailable
+			if h.script.Policy == s2.AppendRetryPolicyAll {
+				status = http.StatusPreconditionFailed
+			}
+			var apiErr *s2.S2Error
+			if !errors.As(err, &apiErr) || apiErr.Status != status {
+				return fmt.Errorf("batch %d: expected status %d, got %v", i, status, err)
+			}
+		}
+		h.proxy.mu.Lock()
+		gotAttempts := h.proxy.attempts[i]
+		h.proxy.mu.Unlock()
+		if gotAttempts != attempts {
+			return fmt.Errorf("batch %d: attempts=%d, want %d", i, gotAttempts, attempts)
+		}
+		if !wantError {
+			end := uint64(len(expected))
+			want := s2.AppendAck{Start: s2.StreamPosition{SeqNum: end - uint64(len(b.Records)), Timestamp: 42}, End: s2.StreamPosition{SeqNum: end, Timestamp: 42}, Tail: s2.StreamPosition{SeqNum: end, Timestamp: 42}}
+			if ack == nil || *ack != want {
+				return fmt.Errorf("batch %d: ack=%+v, want %+v", i, ack, want)
+			}
+			if session != nil && (session.LastAckedPosition() == nil || *session.LastAckedPosition() != want) {
+				return fmt.Errorf("batch %d: last acknowledged position differs from ack", i)
+			}
+		}
+		if session != nil {
+			if err := session.Close(); err != nil {
+				return err
+			}
+		}
+		if wantError && session != nil {
+			break
+		}
+	}
+	got, err := h.stream(len(h.script.Batches)).Read(ctx, &s2.ReadOptions{SeqNum: s2.Uint64(0)})
+	if err != nil {
+		return err
+	}
+	if !sameRecords(got.Records, expected) {
+		return errors.New("committed records differ from model")
+	}
+	tail, err := h.stream(len(h.script.Batches)).CheckTail(ctx)
+	if err != nil || tail.Tail.SeqNum != uint64(len(expected)) {
+		return fmt.Errorf("tail=%+v, err=%v, want %d", tail, err, len(expected))
+	}
+	return nil
+}
+
+func appendBatch(ctx context.Context, stream *s2.StreamClient, session *s2.AppendSession, input *s2.AppendInput) (*s2.AppendAck, error) {
+	if session == nil {
+		return stream.Append(ctx, input)
+	}
+	future, err := session.Submit(input)
+	if err != nil {
+		return nil, err
+	}
+	ticket, err := future.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ticket.Ack(ctx)
+}
+
+func sameRecords(a, b []s2.SequencedRecord) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, r := range a {
+		want := b[i]
+		if r.SeqNum != want.SeqNum || r.Timestamp != want.Timestamp || !bytes.Equal(r.Body, want.Body) || len(r.Headers) != len(want.Headers) {
+			return false
+		}
+		for j, header := range r.Headers {
+			if !bytes.Equal(header.Name, want.Headers[j].Name) || !bytes.Equal(header.Value, want.Headers[j].Value) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func recordBytes(r s2.SequencedRecord) uint64 {
+	n := 8 + len(r.Body) + 2*len(r.Headers)
+	for _, header := range r.Headers {
+		n += len(header.Name) + len(header.Value)
+	}
+	return uint64(n)
+}


### PR DESCRIPTION
Add replayable append scenarios with exact retry counts, sequence guards, ACK ranges, payloads, and tail checks against a trace-derived model. The proxy rejects a request before forwarding it or returns an error after observing Lite's real commit ACK. Negative controls corrupt ACKs and payloads.

Review the expected attempts/copies in `harness.replay`, then the proxy's commit-ACK interception. Sequential tests use fixed client timestamps and one batch per append session. Failure directories retain the trace and wire history.

Validation: Harness race tests against real Lite, harness lint, and workflow validation passed.

Part 2/6 replacing #375. Builds on #377 (merged). Base: `main`. Next: #379.

Ready to review and merge.
