### PR TITLE
test: fuzz read recovery against Lite (3/6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,12 +132,16 @@ jobs:
         run: |
           chmod +x "$S2_LITE_BIN"
           go test -race -count=1 -timeout=3m ./internal/faulttest
+      - name: Fuzz
+        run: |
+          go test ./internal/faulttest -run '^$' -fuzz '^FuzzReplay$' -fuzztime=20s -parallel=1
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: sdk-faults
           path: |
             ${{ runner.temp }}/sdk-faults
+            internal/faulttest/testdata/fuzz
 
   s2-lite-integration:
     name: S2-lite Integration

--- a/internal/faulttest/README.md
+++ b/internal/faulttest/README.md
@@ -22,6 +22,14 @@ Failures retain `trace.json` and `wire.json` in the logged artifact directory:
 S2_FAULT_TRACE=/path/to/trace.json go test ./internal/faulttest -run '^TestReplay$' -count=1
 ```
 
+Streaming reads exercise record/byte limits, compression, fragmented responses,
+and resets or errors after record delivery. Fuzz bytes generate the workload
+and fault plan; sequential replay compares the logical protocol history.
+
+```sh
+go test ./internal/faulttest -run '^$' -fuzz '^FuzzReplay$' -fuzztime=30s -parallel=1
+```
+
 Tests requiring a binary skip when it is unset. CI supplies the required
-binaries and runs the race detector. `S2_FAULT_OUTPUT` chooses the
+binaries and runs the race detector and fuzzers. `S2_FAULT_OUTPUT` chooses the
 artifact parent directory; successful runs clean up their files.

--- a/internal/faulttest/harness_test.go
+++ b/internal/faulttest/harness_test.go
@@ -21,11 +21,14 @@ type harness struct {
 func newHarness(t *testing.T, endpoint string, script trace) *harness {
 	t.Helper()
 	basin, name := provision(t, endpoint)
-	plans := make([]faultPlan, len(script.Batches)+1)
+	plans := make([]faultPlan, len(script.Batches)+2)
 	for i, batch := range script.Batches {
 		plans[i].Fault = batch.Fault
 	}
+	plans[len(script.Batches)+1].Reads = script.ReadFaults
 	p := newFaultProxy(t, endpoint, plans)
+	p.fragment = script.Fragment
+	p.compression = script.Compression
 	dir := resultDir(t)
 	data, _ := json.MarshalIndent(script, "", "  ")
 	if err := os.WriteFile(filepath.Join(dir, "trace.json"), data, 0600); err != nil {
@@ -44,8 +47,8 @@ func (h *harness) stream(id int) *s2.StreamClient {
 	endpoint := fmt.Sprintf("%s/op/%d/v1", h.proxy.endpoint, id)
 	client := s2.New("test", &s2.ClientOptions{
 		BaseURL: endpoint, MakeBasinBaseURL: func(string) string { return endpoint },
-		RequestTimeout: 3 * time.Second,
-		RetryConfig:    &s2.RetryConfig{MaxAttempts: 3, MinBaseDelay: time.Millisecond, MaxBaseDelay: time.Millisecond, AppendRetryPolicy: h.script.Policy},
+		Compression: h.script.Compression, RequestTimeout: 3 * time.Second,
+		RetryConfig: &s2.RetryConfig{MaxAttempts: 3, MinBaseDelay: time.Millisecond, MaxBaseDelay: time.Millisecond, AppendRetryPolicy: h.script.Policy},
 	})
 	return client.Basin(h.basin).Stream(s2.StreamName(h.name))
 }

--- a/internal/faulttest/lite_test.go
+++ b/internal/faulttest/lite_test.go
@@ -60,6 +60,17 @@ func newLite(t testing.TB) *liteProcess {
 	return lite
 }
 
+func fuzzLite(f *testing.F) string {
+	// Workers may exit without cleanup; the coordinator owns Lite.
+	const key = "S2_FAULT_FUZZ_ENDPOINT"
+	if endpoint := os.Getenv(key); endpoint != "" {
+		return endpoint
+	}
+	lite := newLite(f)
+	f.Setenv(key, lite.endpoint)
+	return lite.endpoint
+}
+
 func (p *liteProcess) start() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/faulttest/proxy_test.go
+++ b/internal/faulttest/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -25,18 +26,22 @@ import (
 
 type faultPlan struct {
 	Fault string
+	Reads []readFault
 }
 
 type faultProxy struct {
-	endpoint  string
-	upstream  *url.URL
-	transport *http2.Transport
-	mu        sync.Mutex
-	attempts  map[int]int
-	fired     map[int]bool
-	wire      []string
-	ops       []faultPlan
-	corrupt   func(proto.Message)
+	endpoint    string
+	upstream    *url.URL
+	transport   *http2.Transport
+	mu          sync.Mutex
+	attempts    map[int]int
+	fired       map[int]bool
+	wire        []string
+	ops         []faultPlan
+	readSeen    []chan struct{}
+	corrupt     func(proto.Message)
+	fragment    int
+	compression s2.CompressionType
 }
 
 func newFaultProxy(t *testing.T, endpoint string, plans []faultPlan) *faultProxy {
@@ -46,6 +51,9 @@ func newFaultProxy(t *testing.T, endpoint string, plans []faultPlan) *faultProxy
 		t.Fatal(err)
 	}
 	p := &faultProxy{upstream: u, ops: plans, attempts: make(map[int]int), fired: make(map[int]bool)}
+	for range plans {
+		p.readSeen = append(p.readSeen, make(chan struct{}, 1))
+	}
 	p.transport = &http2.Transport{AllowHTTP: true, DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
 		if u.Scheme == "https" {
 			return (&tls.Dialer{Config: cfg}).DialContext(ctx, network, addr)
@@ -137,8 +145,8 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Del("Content-Length")
 	w.WriteHeader(response.StatusCode)
 	w.(http.Flusher).Flush()
-	if response.StatusCode != http.StatusOK || (fault == "" && p.corrupt == nil) {
-		_, _ = io.Copy(flushWriter{w}, response.Body)
+	if response.StatusCode != http.StatusOK || (fault == "" && len(plan.Reads) == 0 && p.corrupt == nil) {
+		_, _ = io.Copy(flushWriter{w, p.fragment}, response.Body)
 		return
 	}
 	if !streaming {
@@ -153,10 +161,73 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 				data = p.rewrite(data, &pb.ReadBatch{})
 			}
 		}
-		_, _ = (flushWriter{w}).Write(data)
+		_, _ = (flushWriter{w, p.fragment}).Write(data)
 		return
 	}
-	_, _ = io.Copy(flushWriter{w}, response.Body)
+	readPlan := readFault{After: -1}
+	if !appendRequest {
+		if attempt <= len(plan.Reads) {
+			readPlan = plan.Reads[attempt-1]
+		}
+	}
+	frames := framing.NewFrameReader(response.Body)
+	delivered := 0
+	for {
+		if delivered == readPlan.After {
+			p.injectRead(w, id, readPlan.Kind)
+			return
+		}
+		frame, err := frames.ReadFrame()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if err != nil {
+			panic(http.ErrAbortHandler)
+		}
+		data, err := frame.DecompressedBody()
+		if err != nil {
+			panic(http.ErrAbortHandler)
+		}
+		status := 0
+		if frame.StatusCode != nil {
+			status = *frame.StatusCode
+		}
+		if !appendRequest && !frame.Terminal && (readPlan.After >= 0 || len(plan.Reads) > 0) {
+			var batch pb.ReadBatch
+			if proto.Unmarshal(data, &batch) != nil {
+				panic(http.ErrAbortHandler)
+			}
+			if len(batch.Records) > 0 {
+				for _, record := range batch.Records {
+					part, _ := proto.Marshal(&pb.ReadBatch{Records: []*pb.SequencedRecord{record}, Tail: batch.Tail})
+					if !p.writeFrame(w, part, false, status, frame.ReconnectAdvised) {
+						return
+					}
+					select {
+					case <-p.readSeen[id]:
+					case <-req.Context().Done():
+						return
+					}
+					delivered++
+					if delivered == readPlan.After {
+						p.injectRead(w, id, readPlan.Kind)
+						return
+					}
+				}
+				continue
+			}
+		}
+		if p.corrupt != nil && !frame.Terminal {
+			if appendRequest {
+				data = p.rewrite(data, &pb.AppendAck{})
+			} else {
+				data = p.rewrite(data, &pb.ReadBatch{})
+			}
+		}
+		if !p.writeFrame(w, data, frame.Terminal, status, frame.ReconnectAdvised) || frame.Terminal {
+			return
+		}
+	}
 }
 
 func (p *faultProxy) rewrite(data []byte, message proto.Message) []byte {
@@ -171,22 +242,34 @@ func (p *faultProxy) rewrite(data []byte, message proto.Message) []byte {
 	return data
 }
 
+func (p *faultProxy) injectRead(w http.ResponseWriter, id int, kind string) {
+	p.injected(id, kind)
+	switch kind {
+	case "reset":
+		panic(http.ErrAbortHandler)
+	case "unavailable":
+		p.replyError(w, true, http.StatusServiceUnavailable, "unavailable")
+	case "truncate":
+		_, _ = (flushWriter{w, p.fragment}).Write([]byte{0, 0, 10, 0, 1})
+	}
+}
+
 func (p *faultProxy) replyError(w http.ResponseWriter, streaming bool, status int, code string) {
 	data, _ := json.Marshal(s2.ErrorInfo{Code: code, Message: code})
 	if streaming {
 		p.writeFrame(w, data, true, status, false)
 	} else {
 		w.WriteHeader(status)
-		_, _ = (flushWriter{w}).Write(data)
+		_, _ = (flushWriter{w, p.fragment}).Write(data)
 	}
 }
 
 func (p *faultProxy) writeFrame(w http.ResponseWriter, data []byte, terminal bool, status int, reconnect bool) bool {
-	wire := framing.CreateFrameWithStatus(data, terminal, framing.CompressionNone, status)
+	wire := framing.CreateFrameWithStatus(data, terminal, p.compression, status)
 	if reconnect {
 		wire[3] |= 0x10
 	}
-	_, err := (flushWriter{w}).Write(wire)
+	_, err := (flushWriter{w, p.fragment}).Write(wire)
 	return err == nil
 }
 
@@ -199,10 +282,23 @@ func (p *faultProxy) injected(id int, fault string) {
 
 type flushWriter struct {
 	http.ResponseWriter
+	fragment int
 }
 
 func (w flushWriter) Write(data []byte) (int, error) {
-	n, err := w.ResponseWriter.Write(data)
-	w.ResponseWriter.(http.Flusher).Flush()
-	return n, err
+	written := 0
+	for len(data) > 0 {
+		n := len(data)
+		if w.fragment > 0 && n > w.fragment {
+			n = w.fragment
+		}
+		count, err := w.ResponseWriter.Write(data[:n])
+		written += count
+		if err != nil {
+			return written, err
+		}
+		w.ResponseWriter.(http.Flusher).Flush()
+		data = data[n:]
+	}
+	return written, nil
 }

--- a/internal/faulttest/replay_test.go
+++ b/internal/faulttest/replay_test.go
@@ -29,10 +29,20 @@ type batch struct {
 	Match   bool              `json:"match,omitempty"`
 }
 
+type readFault struct {
+	After int    `json:"after"`
+	Kind  string `json:"kind"`
+}
+
 type trace struct {
-	Session bool                 `json:"session"`
-	Policy  s2.AppendRetryPolicy `json:"policy"`
-	Batches []batch              `json:"batches"`
+	Session     bool                 `json:"session"`
+	Policy      s2.AppendRetryPolicy `json:"policy"`
+	Compression s2.CompressionType   `json:"compression,omitempty"`
+	Fragment    int                  `json:"fragment,omitempty"`
+	Batches     []batch              `json:"batches"`
+	ReadFaults  []readFault          `json:"read_faults,omitempty"`
+	Count       uint64               `json:"count,omitempty"`
+	Bytes       uint64               `json:"bytes,omitempty"`
 }
 
 func TestReplay(t *testing.T) {
@@ -51,10 +61,10 @@ func TestReplay(t *testing.T) {
 		checkReplay(t, lite.endpoint, script)
 		return
 	}
-	for mode := byte(0); mode < 4; mode++ {
+	for mode := byte(0); mode < 12; mode++ {
 		for fault := byte(0); fault < 6; fault++ {
 			t.Run(fmt.Sprintf("%d/%d", mode, fault), func(t *testing.T) {
-				checkReplay(t, lite.endpoint, makeTrace([]byte{mode, fault, 3, 1, 255, 192}))
+				checkReplay(t, lite.endpoint, makeTrace([]byte{mode | fault/2<<4, fault, 3, 1, 255, 192}))
 			})
 		}
 	}
@@ -104,9 +114,25 @@ func TestReplayDeterministic(t *testing.T) {
 	}
 }
 
+func FuzzReplay(f *testing.F) {
+	endpoint := fuzzLite(f)
+	f.Add([]byte{0, 0, 3, 1})
+	f.Add([]byte{5, 2, 1, 4})
+	f.Add([]byte{9, 4, 2, 5})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) < 2 || len(data) > 32 {
+			return
+		}
+		checkReplay(t, endpoint, makeTrace(data))
+	})
+}
+
 func makeTrace(data []byte) trace {
 	script := trace{
 		Session: data[0]&1 != 0, Policy: s2.AppendRetryPolicyAll,
+		Compression: s2.CompressionType(data[0] / 4 % 3),
+		Fragment:    []int{0, 1, 7, 1024}[data[0]/4%4],
+		ReadFaults:  []readFault{{After: int(data[1] % 3), Kind: "reset"}, {After: 1, Kind: "unavailable"}},
 	}
 	if data[0]&2 != 0 {
 		script.Policy = s2.AppendRetryPolicyNoSideEffects
@@ -123,6 +149,12 @@ func makeTrace(data []byte) trace {
 			})
 		}
 		script.Batches = append(script.Batches, b)
+	}
+	if data[0]&16 != 0 {
+		script.Count = uint64(data[1]%8 + 1)
+	}
+	if data[0]&32 != 0 {
+		script.Bytes = (uint64(data[1]) + 1) * 32
 	}
 	return script
 }
@@ -144,7 +176,7 @@ func (s trace) validate() error {
 	if s.Policy != s2.AppendRetryPolicyAll && s.Policy != s2.AppendRetryPolicyNoSideEffects {
 		return fmt.Errorf("invalid retry policy %q", s.Policy)
 	}
-	if len(s.Batches) == 0 || len(s.Batches) > 32 {
+	if len(s.Batches) == 0 || len(s.Batches) > 32 || len(s.ReadFaults) > 2 || s.Fragment < 0 || s.Compression > s2.CompressionGzip {
 		return errors.New("invalid trace bounds")
 	}
 	var count int
@@ -171,6 +203,11 @@ func (s trace) validate() error {
 	}
 	if count > 128 || size > 256*1024 {
 		return errors.New("trace exceeds 128 records or 256 KiB")
+	}
+	for _, fault := range s.ReadFaults {
+		if fault.After < 0 || (fault.Kind != "reset" && fault.Kind != "unavailable" && fault.Kind != "truncate") {
+			return fmt.Errorf("invalid read fault %+v", fault)
+		}
 	}
 	return nil
 }
@@ -260,6 +297,39 @@ func (h *harness) replay() error {
 	tail, err := h.stream(len(h.script.Batches)).CheckTail(ctx)
 	if err != nil || tail.Tail.SeqNum != uint64(len(expected)) {
 		return fmt.Errorf("tail=%+v, err=%v, want %d", tail, err, len(expected))
+	}
+	count := uint64(len(expected))
+	if h.script.Count > 0 && h.script.Count < count {
+		count = h.script.Count
+	}
+	opts := &s2.ReadOptions{SeqNum: s2.Uint64(0), Count: &count}
+	expected = expected[:count]
+	if h.script.Bytes > 0 {
+		opts.Bytes = &h.script.Bytes
+		var used uint64
+		for i, record := range expected {
+			used += recordBytes(record)
+			if used > h.script.Bytes {
+				expected = expected[:i]
+				break
+			}
+		}
+	}
+	reader, err := h.stream(len(h.script.Batches)+1).ReadSession(ctx, opts)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	var records []s2.SequencedRecord
+	for reader.Next() {
+		records = append(records, reader.Record())
+		select {
+		case h.proxy.readSeen[len(h.script.Batches)+1] <- struct{}{}:
+		default:
+		}
+	}
+	if reader.Err() != nil || !sameRecords(records, expected) || ctx.Err() != nil {
+		return fmt.Errorf("streaming read: got %d records, want %d; err=%v; context=%v", len(records), len(expected), reader.Err(), ctx.Err())
 	}
 	return nil
 }


### PR DESCRIPTION
Extend replay to streaming reads, count/byte limits, compression, fragmented responses, and read interruptions after SDK delivery. Fuzz bytes generate the workload and fault plan; replay checks the expected record prefix. Healthy responses pass through the proxy unchanged unless a transformation is requested.

Review `makeTrace`, the reader/proxy delivery handshake, and framing changes. The fuzz coordinator owns Lite and shares its endpoint with workers, since workers can exit without cleanup; each trace still gets a fresh basin and stream.

Validation: Harness race tests against real Lite, harness lint, and workflow validation passed. The sequential fuzzer and saved JSON trace replay passed.

Part 3/6 replacing #375. Depends on #378. Next: #380.

Reviewable now; kept as a draft until its predecessor lands. After that merge, rebase onto `main`, retarget this PR to `main`, and mark it ready.
