### PR TITLE
test: check concurrent SDK faults against Lite (5/6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
       - name: Fuzz
         run: |
           go test ./internal/faulttest -run '^$' -fuzz '^FuzzReplay$' -fuzztime=20s -parallel=1
+          go test ./internal/faulttest -run '^$' -fuzz '^FuzzConcurrent$' -fuzztime=20s -parallel=1
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:

--- a/internal/faulttest/README.md
+++ b/internal/faulttest/README.md
@@ -41,6 +41,21 @@ export S2_PORCUPINE=/tmp/s2-porcupine
 go test -race ./internal/faulttest
 ```
 
+Concurrent tests race unary appends, sessions, producers, reads, and tail checks
+against Lite through the proxy, with sequence guards, fencing, and faults.
+Each trace gets a fresh basin; fuzz workers share the coordinator-owned Lite process.
+
+```sh
+go test ./internal/faulttest -run '^$' -fuzz '^FuzzConcurrent$' -fuzztime=30s -parallel=1
+S2_CONCURRENT_TRACE=/path/to/trace.json go test ./internal/faulttest -run '^TestConcurrent$' -count=1
+/tmp/s2-porcupine -file=/path/to/history.jsonl
+```
+
+Concurrent failures retain `history.jsonl` and any checker visualization.
+A trace repeats inputs and fault triggers; Lite timing and goroutine scheduling
+can vary. JSONL rechecks the exact observed history. Unknown appends remain
+pending; writers use `NoSideEffects` to avoid intentional duplicates.
+
 Tests requiring a binary skip when it is unset. CI supplies the required
 binaries and runs the race detector and fuzzers. `S2_FAULT_OUTPUT` chooses the
 artifact parent directory; successful runs clean up their files.

--- a/internal/faulttest/concurrent_test.go
+++ b/internal/faulttest/concurrent_test.go
@@ -1,0 +1,389 @@
+package faulttest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/s2-streamstore/s2-sdk-go/s2"
+)
+
+const (
+	opAppend     = "append"
+	opSession    = "session"
+	opProducer   = "producer"
+	opRead       = "read"
+	opTail       = "tail"
+	readReset    = "read_reset"
+	fenceCommand = "fence"
+)
+
+type operation struct {
+	Kind  string          `json:"kind"`
+	Input *s2.AppendInput `json:"input,omitempty"`
+	Fault string          `json:"fault,omitempty"`
+}
+
+type concurrentTrace struct {
+	Waves       [][]operation      `json:"waves"`
+	Compression s2.CompressionType `json:"compression,omitempty"`
+}
+
+func concurrentScenario(seed byte) concurrentTrace {
+	script := concurrentTrace{Compression: s2.CompressionType(seed % 3)}
+	for wave := range 6 {
+		ops := make([]operation, 0, 5)
+		for writer := range 3 {
+			body := bytes.Repeat([]byte(fmt.Sprintf("seed=%d/wave=%d/writer=%d", seed, wave, writer)), 64)
+			input := &s2.AppendInput{Records: []s2.AppendRecord{{Body: body, Headers: []s2.Header{{Name: []byte("writer"), Value: []byte{byte(writer)}}}}}}
+			kind := []string{opAppend, opSession, opProducer}[writer]
+			switch wave {
+			case 1:
+				input.MatchSeqNum = s2.Uint64(3)
+			case 2:
+				input.Records = []s2.AppendRecord{s2.NewFenceCommandRecord(fmt.Sprintf("fence-%d", writer), nil)}
+				input.MatchSeqNum = s2.Uint64(4)
+			case 3:
+				input.FencingToken = s2.String(fmt.Sprintf("fence-%d", writer))
+			}
+			fault := ""
+			if wave == 4 {
+				fault = []string{afterCommit, beforeCommit, ""}[writer]
+			}
+			ops = append(ops, operation{Kind: kind, Input: input, Fault: fault})
+		}
+		ops = append(ops, operation{Kind: opRead}, operation{Kind: opTail})
+		if wave == 5 {
+			ops[3].Fault = readReset
+		}
+		script.Waves = append(script.Waves, ops)
+	}
+	return script
+}
+
+func (s concurrentTrace) validate() error {
+	if len(s.Waves) == 0 || len(s.Waves) > 32 || s.Compression > s2.CompressionGzip {
+		return fmt.Errorf("invalid concurrent trace bounds")
+	}
+	for _, wave := range s.Waves {
+		if len(wave) == 0 || len(wave) > 8 {
+			return fmt.Errorf("waves must contain 1–8 operations")
+		}
+		for _, op := range wave {
+			switch op.Kind {
+			case opAppend, opSession, opProducer:
+				if op.Input == nil || len(op.Input.Records) != 1 {
+					return fmt.Errorf("concurrent append operations require one record")
+				}
+				if op.Fault != "" && op.Fault != beforeCommit && op.Fault != afterCommit {
+					return fmt.Errorf("invalid append fault %q", op.Fault)
+				}
+			case opRead, opTail:
+				if op.Input != nil || (op.Fault != "" && (op.Kind != opRead || op.Fault != readReset)) {
+					return fmt.Errorf("invalid read/tail operation")
+				}
+			default:
+				return fmt.Errorf("unknown operation %q", op.Kind)
+			}
+		}
+	}
+	return nil
+}
+
+func TestConcurrent(t *testing.T) {
+	checker := checkerBinary(t)
+	lite := newLite(t)
+	if script := loadConcurrentTrace(t); script != nil {
+		runConcurrentLite(t, checker, lite.endpoint, *script)
+		return
+	}
+	for seed := byte(0); seed < 3; seed++ {
+		t.Run(fmt.Sprint(seed), func(t *testing.T) { runConcurrentLite(t, checker, lite.endpoint, concurrentScenario(seed)) })
+	}
+}
+
+func loadConcurrentTrace(t *testing.T) *concurrentTrace {
+	t.Helper()
+	path := os.Getenv("S2_CONCURRENT_TRACE")
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var script concurrentTrace
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&script); err != nil {
+		t.Fatal(err)
+	}
+	return &script
+}
+
+func FuzzConcurrent(f *testing.F) {
+	checker := checkerBinary(f)
+	endpoint := fuzzLite(f)
+	f.Add([]byte{0, 1, 2})
+	f.Add([]byte{2, 3, 4, 5})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) == 0 || len(data) > 8 {
+			return
+		}
+		script := concurrentScenario(data[0])
+		script.Waves = script.Waves[:1]
+		for i, value := range data {
+			wave := []operation{{Kind: opRead}, {Kind: opTail}}
+			for writer := range 2 {
+				input := &s2.AppendInput{Records: []s2.AppendRecord{{Body: []byte{0, byte(i), byte(writer), value}}}}
+				if i > 0 {
+					if value&8 != 0 {
+						input.MatchSeqNum = s2.Uint64(uint64(3 + 2*i))
+					}
+					if value&16 != 0 {
+						input.Records = []s2.AppendRecord{s2.NewFenceCommandRecord(fmt.Sprintf("fuzz-%d", writer), nil)}
+					}
+					if value&32 != 0 {
+						input.FencingToken = s2.String(fmt.Sprintf("fuzz-%d", writer))
+					}
+				}
+				wave = append(wave, operation{Kind: []string{opAppend, opSession, opProducer}[int(value+byte(writer))%3],
+					Input: input})
+			}
+			if i == 0 {
+				wave[2].Fault = []string{"", beforeCommit, afterCommit}[value%3]
+				wave[0].Fault = readReset
+			}
+			script.Waves = append(script.Waves, wave)
+		}
+		runConcurrentLite(t, checker, endpoint, script)
+	})
+}
+
+func runConcurrentLite(t *testing.T, checker, endpoint string, script concurrentTrace) {
+	t.Helper()
+	basin, stream := provision(t, endpoint)
+	runConcurrent(t, checker, endpoint, basin, stream, script)
+}
+
+func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, script concurrentTrace) {
+	t.Helper()
+	if err := script.validate(); err != nil {
+		t.Fatal(err)
+	}
+	dir := resultDir(t)
+	data, err := json.MarshalIndent(script, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "trace.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	plans := make([]faultPlan, 0, len(script.Waves)*len(script.Waves[0]))
+	for _, wave := range script.Waves {
+		for _, op := range wave {
+			plans = append(plans, faultPlan{Input: op.Input, Fault: op.Fault})
+		}
+	}
+	p := newFaultProxy(t, endpoint, plans)
+	h := &history{}
+	defer func() {
+		_ = os.WriteFile(filepath.Join(dir, "history.jsonl"), h.jsonl(), 0600)
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		wire, _ := json.MarshalIndent(p.wire, "", "  ")
+		_ = os.WriteFile(filepath.Join(dir, "wire.json"), wire, 0600)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	var acknowledged []observedAppend
+	var resultMu sync.Mutex
+	var violations []error
+	id := 0
+	for _, wave := range script.Waves {
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for _, op := range wave {
+			opID := id
+			id++
+			var input any = "CheckTail"
+			if op.Input != nil {
+				input = appendStart(op.Input)
+			} else if op.Kind == opRead {
+				input = "Read"
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				h.start(opID, input)
+				client := testClient(fmt.Sprintf("%s/op/%d/v1", p.endpoint, opID), script.Compression).Basin(basin).Stream(s2.StreamName(streamName))
+				var violation error
+				switch op.Kind {
+				case opAppend, opSession, opProducer:
+					ack, err := performAppend(ctx, client, op)
+					h.finish(opID, appendFinish(ack, err))
+					if err == nil && op.Fault == afterCommit {
+						violation = fmt.Errorf("op %d: append succeeded despite a withheld ACK", opID)
+					}
+					if op.Fault != afterCommit && err != nil {
+						var apiErr *s2.S2Error
+						guarded := op.Input.MatchSeqNum != nil || op.Input.FencingToken != nil
+						if !guarded || !errors.As(err, &apiErr) || apiErr.Status != http.StatusPreconditionFailed {
+							violation = fmt.Errorf("op %d: unexpected append failure: %w", opID, err)
+						}
+					}
+					if err == nil {
+						if ack.End.SeqNum != ack.Start.SeqNum+uint64(len(op.Input.Records)) || ack.Tail.SeqNum < ack.End.SeqNum {
+							violation = fmt.Errorf("op %d: invalid ack %+v", opID, ack)
+						}
+						resultMu.Lock()
+						acknowledged = append(acknowledged, observedAppend{input: op.Input, start: ack.Start.SeqNum, end: ack.End.SeqNum, tail: ack.Tail.SeqNum})
+						resultMu.Unlock()
+					}
+				case opRead:
+					records, err := readPrefix(ctx, client, p.readSeen[opID])
+					if err != nil {
+						h.finish(opID, "ReadFailure")
+						violation = fmt.Errorf("op %d: read failed: %w", opID, err)
+					} else {
+						h.finish(opID, map[string]any{"ReadSuccess": map[string]uint64{"tail": uint64(len(records)), "stream_hash": streamHash(records)}})
+						violation = contiguous(records)
+					}
+				case opTail:
+					tail, err := client.CheckTail(ctx)
+					if err != nil {
+						h.finish(opID, "CheckTailFailure")
+						violation = fmt.Errorf("op %d: tail failed: %w", opID, err)
+					} else {
+						h.finish(opID, map[string]any{"CheckTailSuccess": map[string]uint64{"tail": tail.Tail.SeqNum}})
+					}
+				}
+				if violation != nil {
+					resultMu.Lock()
+					violations = append(violations, violation)
+					resultMu.Unlock()
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+		if ctx.Err() != nil {
+			t.Fatal(ctx.Err())
+		}
+	}
+	client := testClient(endpoint, script.Compression).Basin(basin).Stream(s2.StreamName(streamName))
+	h.start(id, "Read")
+	records, err := readPrefix(ctx, client, nil)
+	if err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+	h.finish(id, map[string]any{"ReadSuccess": map[string]uint64{"tail": uint64(len(records)), "stream_hash": streamHash(records)}})
+	if err := contiguous(records); err != nil {
+		t.Fatal(err)
+	}
+	p.mu.Lock()
+	acknowledged = append(acknowledged, p.committed...)
+	p.mu.Unlock()
+	for _, observed := range acknowledged {
+		if observed.end != observed.start+uint64(len(observed.input.Records)) || observed.tail < observed.end || observed.tail > uint64(len(records)) {
+			t.Fatalf("invalid or lost acknowledged range: [%d,%d), tail=%d, records=%d", observed.start, observed.end, observed.tail, len(records))
+		}
+		for i, input := range observed.input.Records {
+			got := records[observed.start+uint64(i)]
+			want := s2.SequencedRecord{SeqNum: got.SeqNum, Timestamp: got.Timestamp, Headers: input.Headers, Body: input.Body}
+			if !sameRecords([]s2.SequencedRecord{got}, []s2.SequencedRecord{want}) {
+				t.Fatalf("ack maps to different payload at %d", got.SeqNum)
+			}
+		}
+	}
+	if len(violations) > 0 {
+		t.Fatal(violations)
+	}
+	p.mu.Lock()
+	for id, op := range p.ops {
+		if op.Fault != "" && !p.fired[id] {
+			t.Errorf("op %d: fault %s was not injected", id, op.Fault)
+		}
+	}
+	p.mu.Unlock()
+	if err := checkHistory(checker, dir, h.jsonl()); err != nil {
+		t.Fatalf("%v; artifacts: %s", err, dir)
+	}
+}
+
+func performAppend(ctx context.Context, stream *s2.StreamClient, op operation) (*s2.AppendAck, error) {
+	if op.Kind == opAppend {
+		return stream.Append(ctx, op.Input)
+	}
+	session, err := stream.AppendSession(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+	if op.Kind == opSession {
+		return appendBatch(ctx, stream, session, op.Input)
+	}
+	batcher := s2.NewBatcher(ctx, &s2.BatchingOptions{MaxRecords: 1, MatchSeqNum: op.Input.MatchSeqNum, FencingToken: op.Input.FencingToken})
+	producer := s2.NewProducer(ctx, batcher, session)
+	defer producer.Close()
+	future, err := producer.Submit(op.Input.Records[0])
+	if err != nil {
+		return nil, err
+	}
+	ticket, err := future.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := producer.Flush(ctx); err != nil {
+		return nil, err
+	}
+	ack, err := ticket.Ack(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ack.BatchAppendAck(), nil
+}
+
+func readPrefix(ctx context.Context, stream *s2.StreamClient, seen chan<- struct{}) ([]s2.SequencedRecord, error) {
+	reader, err := stream.ReadSession(ctx, &s2.ReadOptions{SeqNum: s2.Uint64(0), Count: s2.Uint64(math.MaxUint64), Wait: s2.Int32(0)})
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	var records []s2.SequencedRecord
+	for reader.Next() {
+		records = append(records, reader.Record())
+		select {
+		case seen <- struct{}{}:
+		default:
+		}
+	}
+	if ctx.Err() != nil {
+		return records, ctx.Err()
+	}
+	err = reader.Err()
+	var rangeErr *s2.RangeNotSatisfiableError
+	if errors.As(err, &rangeErr) && rangeErr.Tail != nil && rangeErr.Tail.SeqNum == uint64(len(records)) {
+		err = nil
+	}
+	return records, err
+}
+
+func contiguous(records []s2.SequencedRecord) error {
+	for i, record := range records {
+		if record.SeqNum != uint64(i) {
+			return fmt.Errorf("non-contiguous read: record %d has sequence %d", i, record.SeqNum)
+		}
+	}
+	return nil
+}

--- a/internal/faulttest/history_test.go
+++ b/internal/faulttest/history_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
-const fenceCommand = "fence"
-
 const verificationRevision = "b4af8c8ef4965d9b335101c422eadb33f3169004"
 
 type historyEvent struct {

--- a/internal/faulttest/proxy_test.go
+++ b/internal/faulttest/proxy_test.go
@@ -25,8 +25,14 @@ import (
 )
 
 type faultPlan struct {
+	Input *s2.AppendInput
 	Fault string
 	Reads []readFault
+}
+
+type observedAppend struct {
+	input            *s2.AppendInput
+	start, end, tail uint64
 }
 
 type faultProxy struct {
@@ -36,6 +42,7 @@ type faultProxy struct {
 	mu          sync.Mutex
 	attempts    map[int]int
 	fired       map[int]bool
+	committed   []observedAppend
 	wire        []string
 	ops         []faultPlan
 	readSeen    []chan struct{}
@@ -135,6 +142,9 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		if err != nil || proto.Unmarshal(data, &ack) != nil || ack.Start == nil || ack.End == nil || ack.Tail == nil {
 			panic(http.ErrAbortHandler)
 		}
+		p.mu.Lock()
+		p.committed = append(p.committed, observedAppend{input: plan.Input, start: ack.Start.SeqNum, end: ack.End.SeqNum, tail: ack.Tail.SeqNum})
+		p.mu.Unlock()
 		p.injected(id, fault)
 		p.replyError(w, streaming, http.StatusServiceUnavailable, "unavailable")
 		return
@@ -168,6 +178,9 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	if !appendRequest {
 		if attempt <= len(plan.Reads) {
 			readPlan = plan.Reads[attempt-1]
+		}
+		if fault == readReset {
+			readPlan = readFault{After: 1, Kind: "reset"}
 		}
 	}
 	frames := framing.NewFrameReader(response.Body)


### PR DESCRIPTION
Race unary appends, sessions, producers, reads, and tail checks against real Lite through the existing fault proxy. Exercise sequence guards, fencing, rejected requests, withheld commit ACKs, and interrupted reads. Check observed histories with Porcupine and compare acknowledged payloads with the final stream.

Review the workload waves, start gate and outcome checks in `runConcurrent`, then final ACK validation. Concurrent traces replay operations and fault triggers; scheduling can vary. CI adds concurrent fuzzing, with coordinator-owned Lite and fresh basins per trace.

Validation: Harness race tests against real Lite, harness lint, and workflow validation passed. The sequential fuzzer and saved JSON trace replay passed. Shared-checker controls passed. Concurrent fuzzing passed with coordinator-owned Lite.

Part 5/6 replacing #375. Depends on #380. Next: #382.

Reviewable now; kept as a draft until its predecessor lands. After that merge, rebase onto `main`, retarget this PR to `main`, and mark it ready.
