### PR TITLE
test: verify SDK durability across Lite crashes (6/6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           name: server-binary
           path: ${{ runner.temp }}/s2-lite
-      - name: Test Lite fault harness
+      - name: Test faults and crash recovery
         run: |
           chmod +x "$S2_LITE_BIN"
           go test -race -count=1 -timeout=3m ./internal/faulttest

--- a/internal/faulttest/README.md
+++ b/internal/faulttest/README.md
@@ -56,6 +56,15 @@ A trace repeats inputs and fault triggers; Lite timing and goroutine scheduling
 can vary. JSONL rechecks the exact observed history. Unknown appends remain
 pending; writers use `NoSideEffects` to avoid intentional duplicates.
 
+`TestLiteDurability` kills Lite after observing a committed ACK and restarts it
+on the same storage. It checks the history, acknowledged payloads, a second
+restart, and persisted fencing. Each crash test owns a separate process and
+storage directory. Use `S2_CONCURRENT_TRACE` with this test to replay crashes.
+
+`TestConcurrentEndpoint` accepts `S2_FAULT_ENDPOINT` and `S2_FAULT_ACCESS_TOKEN`
+for an existing shared endpoint, through the same proxy. It creates and deletes
+a dedicated test basin.
+
 Tests requiring a binary skip when it is unset. CI supplies the required
 binaries and runs the race detector and fuzzers. `S2_FAULT_OUTPUT` chooses the
 artifact parent directory; successful runs clean up their files.

--- a/internal/faulttest/concurrent_test.go
+++ b/internal/faulttest/concurrent_test.go
@@ -18,13 +18,14 @@ import (
 )
 
 const (
-	opAppend     = "append"
-	opSession    = "session"
-	opProducer   = "producer"
-	opRead       = "read"
-	opTail       = "tail"
-	readReset    = "read_reset"
-	fenceCommand = "fence"
+	opAppend         = "append"
+	opSession        = "session"
+	opProducer       = "producer"
+	opRead           = "read"
+	opTail           = "tail"
+	readReset        = "read_reset"
+	crashAfterCommit = "crash_after_commit"
+	fenceCommand     = "fence"
 )
 
 type operation struct {
@@ -84,7 +85,7 @@ func (s concurrentTrace) validate() error {
 				if op.Input == nil || len(op.Input.Records) != 1 {
 					return fmt.Errorf("concurrent append operations require one record")
 				}
-				if op.Fault != "" && op.Fault != beforeCommit && op.Fault != afterCommit {
+				if op.Fault != "" && op.Fault != beforeCommit && op.Fault != afterCommit && op.Fault != crashAfterCommit {
 					return fmt.Errorf("invalid append fault %q", op.Fault)
 				}
 			case opRead, opTail:
@@ -172,10 +173,10 @@ func FuzzConcurrent(f *testing.F) {
 func runConcurrentLite(t *testing.T, checker, endpoint string, script concurrentTrace) {
 	t.Helper()
 	basin, stream := provision(t, endpoint)
-	runConcurrent(t, checker, endpoint, basin, stream, script)
+	runConcurrent(t, checker, endpoint, basin, stream, script, nil, nil)
 }
 
-func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, script concurrentTrace) {
+func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, script concurrentTrace, crash func() error, afterWave func() error) {
 	t.Helper()
 	if err := script.validate(); err != nil {
 		t.Fatal(err)
@@ -195,6 +196,7 @@ func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, sc
 		}
 	}
 	p := newFaultProxy(t, endpoint, plans)
+	p.crash = crash
 	h := &history{}
 	defer func() {
 		_ = os.WriteFile(filepath.Join(dir, "history.jsonl"), h.jsonl(), 0600)
@@ -212,6 +214,15 @@ func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, sc
 	for _, wave := range script.Waves {
 		var wg sync.WaitGroup
 		start := make(chan struct{})
+		crashing := false
+		for _, op := range wave {
+			if op.Fault == crashAfterCommit {
+				if crash == nil {
+					t.Fatal("crash_after_commit requires a managed Lite process")
+				}
+				crashing = true
+			}
+		}
 		for _, op := range wave {
 			opID := id
 			id++
@@ -232,10 +243,10 @@ func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, sc
 				case opAppend, opSession, opProducer:
 					ack, err := performAppend(ctx, client, op)
 					h.finish(opID, appendFinish(ack, err))
-					if err == nil && op.Fault == afterCommit {
+					if err == nil && (op.Fault == afterCommit || op.Fault == crashAfterCommit) {
 						violation = fmt.Errorf("op %d: append succeeded despite a withheld ACK", opID)
 					}
-					if op.Fault != afterCommit && err != nil {
+					if !crashing && op.Fault != afterCommit && err != nil {
 						var apiErr *s2.S2Error
 						guarded := op.Input.MatchSeqNum != nil || op.Input.FencingToken != nil
 						if !guarded || !errors.As(err, &apiErr) || apiErr.Status != http.StatusPreconditionFailed {
@@ -254,7 +265,9 @@ func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, sc
 					records, err := readPrefix(ctx, client, p.readSeen[opID])
 					if err != nil {
 						h.finish(opID, "ReadFailure")
-						violation = fmt.Errorf("op %d: read failed: %w", opID, err)
+						if !crashing {
+							violation = fmt.Errorf("op %d: read failed: %w", opID, err)
+						}
 					} else {
 						h.finish(opID, map[string]any{"ReadSuccess": map[string]uint64{"tail": uint64(len(records)), "stream_hash": streamHash(records)}})
 						violation = contiguous(records)
@@ -263,7 +276,9 @@ func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, sc
 					tail, err := client.CheckTail(ctx)
 					if err != nil {
 						h.finish(opID, "CheckTailFailure")
-						violation = fmt.Errorf("op %d: tail failed: %w", opID, err)
+						if !crashing {
+							violation = fmt.Errorf("op %d: tail failed: %w", opID, err)
+						}
 					} else {
 						h.finish(opID, map[string]any{"CheckTailSuccess": map[string]uint64{"tail": tail.Tail.SeqNum}})
 					}
@@ -277,6 +292,11 @@ func runConcurrent(t *testing.T, checker, endpoint, basin, streamName string, sc
 		}
 		close(start)
 		wg.Wait()
+		if afterWave != nil {
+			if err := afterWave(); err != nil {
+				t.Fatal(err)
+			}
+		}
 		if ctx.Err() != nil {
 			t.Fatal(ctx.Err())
 		}

--- a/internal/faulttest/durability_test.go
+++ b/internal/faulttest/durability_test.go
@@ -1,0 +1,89 @@
+package faulttest
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/s2-streamstore/s2-sdk-go/s2"
+)
+
+func TestLiteDurability(t *testing.T) {
+	checker := checkerBinary(t)
+	if script := loadConcurrentTrace(t); script != nil {
+		checkLiteDurability(t, checker, *script)
+		return
+	}
+	for writer, kind := range []string{opAppend, opSession, opProducer} {
+		t.Run(kind, func(t *testing.T) {
+			script := concurrentScenario(byte(writer))
+			for i := range 3 {
+				script.Waves[4][i].Fault = ""
+			}
+			script.Waves[4][writer].Fault = crashAfterCommit
+			script.Waves[4][(writer+1)%3].Fault = beforeCommit
+			checkLiteDurability(t, checker, script)
+		})
+	}
+}
+
+func checkLiteDurability(t *testing.T, checker string, script concurrentTrace) {
+	t.Helper()
+	lite := newLite(t)
+	basin, name := provision(t, lite.endpoint)
+	var once sync.Once
+	var crashErr error
+	runConcurrent(t, checker, lite.endpoint, basin, name, script, func() error {
+		once.Do(func() { crashErr = lite.kill() })
+		return crashErr
+	}, lite.start)
+	if lite.generation != 2 {
+		t.Fatalf("expected an injected crash and restart, got %d generations", lite.generation)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	stream := testClient(lite.endpoint, s2.CompressionNone).Basin(basin).Stream(s2.StreamName(name))
+	before, err := readPrefix(ctx, stream, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lite.kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := lite.start(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := readPrefix(ctx, stream, nil)
+	if err != nil || !sameRecords(before, after) {
+		t.Fatalf("durable records changed after SIGKILL: before=%d after=%d err=%v", len(before), len(after), err)
+	}
+	input := &s2.AppendInput{Records: []s2.AppendRecord{{Body: []byte("after-restart")}}, MatchSeqNum: s2.Uint64(uint64(len(after))), FencingToken: s2.String("stale-after-restart")}
+	_, err = stream.Append(ctx, input)
+	var apiErr *s2.S2Error
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusPreconditionFailed {
+		t.Fatalf("stale fence accepted after restart: %v", err)
+	}
+	for _, record := range after {
+		if record.IsCommandRecord() && string(record.Headers[0].Value) == fenceCommand {
+			input.FencingToken = s2.String(string(record.Body))
+		}
+	}
+	ack, err := stream.Append(ctx, input)
+	if err != nil || ack.Start.SeqNum != uint64(len(after)) {
+		t.Fatalf("append at recovered tail: ack=%+v err=%v", ack, err)
+	}
+}
+
+func TestConcurrentEndpoint(t *testing.T) {
+	endpoint := os.Getenv("S2_FAULT_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("set S2_FAULT_ENDPOINT to test an existing shared S2 endpoint")
+	}
+	checker := checkerBinary(t)
+	basin, name := provision(t, endpoint)
+	runConcurrent(t, checker, endpoint, basin, name, concurrentScenario(0), nil, nil)
+}

--- a/internal/faulttest/proxy_test.go
+++ b/internal/faulttest/proxy_test.go
@@ -46,6 +46,7 @@ type faultProxy struct {
 	wire        []string
 	ops         []faultPlan
 	readSeen    []chan struct{}
+	crash       func() error
 	corrupt     func(proto.Message)
 	fragment    int
 	compression s2.CompressionType
@@ -127,7 +128,7 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	defer response.Body.Close()
 	streaming := req.Header.Get("Content-Type") == "s2s/proto"
 	appendRequest := req.Method == http.MethodPost
-	if response.StatusCode == http.StatusOK && appendRequest && fault == afterCommit {
+	if response.StatusCode == http.StatusOK && appendRequest && (fault == afterCommit || fault == crashAfterCommit) {
 		var data []byte
 		if streaming {
 			frame, readErr := framing.NewFrameReader(response.Body).ReadFrame()
@@ -145,6 +146,14 @@ func (p *faultProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		p.mu.Lock()
 		p.committed = append(p.committed, observedAppend{input: plan.Input, start: ack.Start.SeqNum, end: ack.End.SeqNum, tail: ack.Tail.SeqNum})
 		p.mu.Unlock()
+		if fault == crashAfterCommit {
+			if err := p.crash(); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			p.injected(id, fault)
+			panic(http.ErrAbortHandler)
+		}
 		p.injected(id, fault)
 		p.replyError(w, streaming, http.StatusServiceUnavailable, "unavailable")
 		return


### PR DESCRIPTION
Extend the Lite-backed concurrent harness with process crashes. After observing a real commit ACK, kill Lite before delivering it and restart on the same storage. Check the history, acknowledged payloads, a second restart, and persisted fencing. Each crash test owns a separate process and storage directory.

Review `durability_test.go`, then the crash hooks in the proxy and runner. The optional existing-endpoint test also uses the same proxy and provisions a dedicated basin.

Validation: Harness race tests against real Lite, harness lint, and workflow validation passed. The sequential fuzzer and saved JSON trace replay passed. Shared-checker controls passed. Concurrent fuzzing passed with coordinator-owned Lite. Real Lite SIGKILL/restart checks passed.

Part 6/6 replacing #375. Depends on #381.

Reviewable now; kept as a draft until its predecessor lands. After that merge, rebase onto `main`, retarget this PR to `main`, and mark it ready.
