### PR TITLE
feat: s2-stream-config header support

### DIFF
--- a/s2/append.go
+++ b/s2/append.go
@@ -58,6 +58,7 @@ func (s *StreamClient) Append(ctx context.Context, input *AppendInput) (*AppendA
 			pbInput,
 			&pbAck,
 			s.encryptionKey,
+			prepared.StreamConfig,
 		); err != nil {
 			return nil, err
 		}
@@ -74,6 +75,7 @@ func (s *StreamClient) Append(ctx context.Context, input *AppendInput) (*AppendA
 
 type transportAppendSession struct {
 	streamClient      *StreamClient
+	streamConfig      *StreamConfig
 	acksCh            chan *AppendAck
 	errorsCh          chan error
 	closed            chan struct{}
@@ -89,7 +91,7 @@ type transportAppendSession struct {
 	halfCloseOnce     sync.Once
 }
 
-func (s *StreamClient) createAppendSession(ctx context.Context) (*transportAppendSession, error) {
+func (s *StreamClient) createAppendSession(ctx context.Context, streamConfig *StreamConfig) (*transportAppendSession, error) {
 	if s.appendSessionFactory != nil {
 		return s.appendSessionFactory(ctx)
 	}
@@ -98,6 +100,7 @@ func (s *StreamClient) createAppendSession(ctx context.Context) (*transportAppen
 
 	session := &transportAppendSession{
 		streamClient: s,
+		streamConfig: streamConfig,
 		acksCh:       make(chan *AppendAck, appendAckChannelBuffer),
 		errorsCh:     make(chan error, 1),
 		closed:       make(chan struct{}),
@@ -140,6 +143,9 @@ func (p *transportAppendSession) start(ctx context.Context) error {
 		req.Header.Set("s2-basin", basinName)
 	}
 	setEncryptionKeyHeader(req.Header, p.streamClient.encryptionKey)
+	if err := setStreamConfigHeader(req.Header, p.streamConfig); err != nil {
+		return err
+	}
 
 	p.mu.Lock()
 	p.requestWriter = pipeWriter

--- a/s2/append_session.go
+++ b/s2/append_session.go
@@ -420,7 +420,7 @@ func (r *AppendSession) getSession() error {
 	logInfo(r.streamClient.logger, "append pump opening transport session",
 		"stream", string(r.streamClient.name))
 
-	session, err := r.streamClient.createAppendSession(r.pumpCtx)
+	session, err := r.streamClient.createAppendSession(r.pumpCtx, r.options.StreamConfig)
 	if err != nil {
 		logError(r.streamClient.logger, "append pump failed to open transport session",
 			"stream", string(r.streamClient.name),

--- a/s2/encryption_test.go
+++ b/s2/encryption_test.go
@@ -244,7 +244,7 @@ func TestStreamWithOptionsAppendSessionSetsEncryptionHeader(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	session, err := stream.createAppendSession(ctx)
+	session, err := stream.createAppendSession(ctx, nil)
 	if err != nil {
 		t.Fatalf("create append session failed: %v", err)
 	}

--- a/s2/example_test.go
+++ b/s2/example_test.go
@@ -404,6 +404,27 @@ func ExampleStreamClient_Append() {
 	fmt.Printf("appended at seq=%d\n", ack.Start.SeqNum)
 }
 
+func ExampleStreamClient_Append_streamConfig() {
+	client := s2.New("your-access-token", nil)
+	stream := client.Basin("my-basin").Stream("my-stream")
+	ctx := context.Background()
+
+	// Applied only if the basin has create-on-append enabled and this append creates the stream.
+	ack, err := stream.Append(ctx, &s2.AppendInput{
+		Records: []s2.AppendRecord{
+			{Body: []byte("hello world")},
+		},
+		StreamConfig: &s2.StreamConfig{
+			RetentionPolicy: &s2.RetentionPolicy{Age: s2.Int64(3600)},
+		},
+	})
+	if err != nil {
+		log.Fatalf("append: %v", err)
+	}
+
+	fmt.Printf("appended at seq=%d\n", ack.Start.SeqNum)
+}
+
 func ExampleStreamClient_Read() {
 	client := s2.New("your-access-token", nil)
 	stream := client.Basin("my-basin").Stream("my-stream")

--- a/s2/http.go
+++ b/s2/http.go
@@ -128,6 +128,7 @@ func (h *httpClient) requestProto(
 	body proto.Message,
 	result proto.Message,
 	encryptionKey *EncryptionKey,
+	streamConfig *StreamConfig,
 ) error {
 	const protoContentType = "application/protobuf"
 	logInfo(h.logger, "s2 http proto request",
@@ -135,6 +136,7 @@ func (h *httpClient) requestProto(
 		"path", path,
 		"url", h.baseURL+path,
 		"encryption", encryptionKey != nil,
+		"stream_config", streamConfig != nil,
 		"compression", h.compression.ContentEncoding(),
 	)
 
@@ -179,6 +181,9 @@ func (h *httpClient) requestProto(
 		req.Header.Set("s2-basin", h.basinName)
 	}
 	setEncryptionKeyHeader(req.Header, encryptionKey)
+	if err := setStreamConfigHeader(req.Header, streamConfig); err != nil {
+		return err
+	}
 
 	resp, err := h.client.Do(req)
 	if err != nil {

--- a/s2/read.go
+++ b/s2/read.go
@@ -48,6 +48,10 @@ type ReadOptions struct {
 	// Filtering is performed client-side.
 	// Defaults to false.
 	IgnoreCommandRecords bool `json:"-"`
+	// Stream configuration to apply if the stream is created on read.
+	// Unset fields inherit the basin's default stream configuration.
+	// Ignored if the stream already exists.
+	StreamConfig *StreamConfig `json:"-"`
 }
 
 func buildReadQueryParams(opts *ReadOptions) string {
@@ -93,6 +97,11 @@ func (s *StreamClient) Read(ctx context.Context, opts *ReadOptions) (*ReadBatch,
 		path += "?" + queryParams
 	}
 
+	var streamConfig *StreamConfig
+	if opts != nil {
+		streamConfig = opts.StreamConfig
+	}
+
 	batch, err := withRetries(ctx, s.basinClient.retryConfig, s.logger, func() (*ReadBatch, error) {
 		httpClient := &httpClient{
 			client:      s.basinClient.httpClient,
@@ -111,6 +120,7 @@ func (s *StreamClient) Read(ctx context.Context, opts *ReadOptions) (*ReadBatch,
 			nil,
 			&pbBatch,
 			s.encryptionKey,
+			streamConfig,
 		); err != nil {
 			return nil, err
 		}
@@ -470,6 +480,11 @@ func (r *streamReader) runOnce(ctx context.Context, opts *ReadOptions) error {
 		req.Header.Set("s2-basin", basinName)
 	}
 	setEncryptionKeyHeader(req.Header, r.streamClient.encryptionKey)
+	if opts != nil {
+		if err := setStreamConfigHeader(req.Header, opts.StreamConfig); err != nil {
+			return err
+		}
+	}
 
 	resp, err := r.streamClient.getHTTPClient().Do(req)
 	if err != nil {

--- a/s2/stream.go
+++ b/s2/stream.go
@@ -2,6 +2,7 @@ package s2
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -60,6 +61,22 @@ func (b *BasinClient) StreamWithOptions(name StreamName, opts *StreamOptions) *S
 
 func (s *StreamClient) Name() StreamName {
 	return s.name
+}
+
+const s2StreamConfigHeader = "s2-stream-config"
+
+func setStreamConfigHeader(headers http.Header, config *StreamConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		return newValidationError(fmt.Sprintf("encode stream config: %v", err))
+	}
+
+	headers.Set(s2StreamConfigHeader, string(encoded))
+	return nil
 }
 
 func (s *StreamClient) getHTTPClient() *http.Client {
@@ -260,6 +277,7 @@ func cloneAppendInput(input *AppendInput) *AppendInput {
 		Records:      cloneAppendRecords(input.Records),
 		MatchSeqNum:  cloneUint64Ptr(input.MatchSeqNum),
 		FencingToken: cloneStringPtr(input.FencingToken),
+		StreamConfig: input.StreamConfig,
 	}
 }
 

--- a/s2/stream_config_header_test.go
+++ b/s2/stream_config_header_test.go
@@ -1,0 +1,160 @@
+package s2
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	pb "github.com/s2-streamstore/s2-sdk-go/generated"
+	"google.golang.org/protobuf/proto"
+)
+
+const testStreamConfigHeader = `{"delete_on_empty":{"min_age_secs":300},"retention_policy":{"age":3600}}`
+
+func testStreamConfig() *StreamConfig {
+	return &StreamConfig{
+		RetentionPolicy: &RetentionPolicy{Age: Int64(3600)},
+		DeleteOnEmpty:   &DeleteOnEmptyConfig{MinAgeSecs: Int64(300)},
+	}
+}
+
+func TestAppendSetsStreamConfigHeader(t *testing.T) {
+	rt := &streamConfigHeaderRoundTripper{response: &pb.AppendAck{}}
+	stream := newTestStreamClientWithTransport(rt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := stream.Append(ctx, &AppendInput{
+		Records:      []AppendRecord{{Body: []byte("hello")}},
+		StreamConfig: testStreamConfig(),
+	})
+	if err != nil {
+		t.Fatalf("append failed: %v", err)
+	}
+
+	if rt.header != testStreamConfigHeader {
+		t.Fatalf("expected stream config header %q, got %q", testStreamConfigHeader, rt.header)
+	}
+}
+
+func TestReadSetsStreamConfigHeader(t *testing.T) {
+	rt := &streamConfigHeaderRoundTripper{response: &pb.ReadBatch{}}
+	stream := newTestStreamClientWithTransport(rt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := stream.Read(ctx, &ReadOptions{Count: Uint64(1), StreamConfig: testStreamConfig()})
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	if rt.header != testStreamConfigHeader {
+		t.Fatalf("expected stream config header %q, got %q", testStreamConfigHeader, rt.header)
+	}
+}
+
+func TestAppendSessionSetsStreamConfigHeader(t *testing.T) {
+	rt := &streamConfigHeaderRoundTripper{headerCh: make(chan string, 1)}
+	stream := newTestStreamClientWithTransport(rt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	session, err := stream.createAppendSession(ctx, testStreamConfig())
+	if err != nil {
+		t.Fatalf("create append session failed: %v", err)
+	}
+	defer session.Close()
+
+	assertHeaderCaptured(t, rt.headerCh, testStreamConfigHeader)
+}
+
+func TestReadSessionSetsStreamConfigHeader(t *testing.T) {
+	rt := &streamConfigHeaderRoundTripper{headerCh: make(chan string, 1)}
+	stream := newTestStreamClientWithTransport(rt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	reader := &streamReader{
+		streamClient: stream,
+		logger:       stream.logger,
+	}
+
+	opts := &ReadOptions{Count: Uint64(1), StreamConfig: testStreamConfig()}
+	if err := reader.runOnce(ctx, opts); err != nil {
+		t.Fatalf("read session runOnce failed: %v", err)
+	}
+
+	assertHeaderCaptured(t, rt.headerCh, testStreamConfigHeader)
+}
+
+func TestAppendWithoutStreamConfigOmitsHeader(t *testing.T) {
+	rt := &streamConfigHeaderRoundTripper{response: &pb.AppendAck{}}
+	stream := newTestStreamClientWithTransport(rt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := stream.Append(ctx, &AppendInput{
+		Records: []AppendRecord{{Body: []byte("hello")}},
+	})
+	if err != nil {
+		t.Fatalf("append failed: %v", err)
+	}
+
+	if rt.present {
+		t.Fatalf("expected no stream config header, got %q", rt.header)
+	}
+}
+
+type streamConfigHeaderRoundTripper struct {
+	header   string
+	present  bool
+	headerCh chan string
+	response proto.Message
+}
+
+func (r *streamConfigHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.header = req.Header.Get(s2StreamConfigHeader)
+	_, r.present = req.Header[http.CanonicalHeaderKey(s2StreamConfigHeader)]
+	if r.headerCh != nil {
+		select {
+		case r.headerCh <- r.header:
+		default:
+		}
+	}
+
+	body := io.NopCloser(bytes.NewReader(nil))
+	if r.response != nil {
+		data, err := proto.Marshal(r.response)
+		if err != nil {
+			return nil, err
+		}
+		body = io.NopCloser(bytes.NewReader(data))
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       body,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func newTestStreamClientWithTransport(rt http.RoundTripper) *StreamClient {
+	httpClient := &http.Client{Transport: rt}
+	basin := &BasinClient{
+		baseURL:     "http://example.com/v1",
+		accessToken: "token",
+		httpClient:  httpClient,
+	}
+	basin.client = &Client{streamingClient: httpClient}
+
+	return basin.Stream("test")
+}

--- a/s2/types.go
+++ b/s2/types.go
@@ -572,6 +572,12 @@ type AppendInput struct {
 	MatchSeqNum *uint64 `json:"match_seq_num,omitempty"`
 	// Enforce a fencing token, which starts out as an empty string that can be overridden by a `fence` command record.
 	FencingToken *string `json:"fencing_token,omitempty"`
+	// Stream configuration to apply if the stream is created on append.
+	// Unset fields inherit the basin's default stream configuration.
+	// Ignored if the stream already exists.
+	// Only used by [StreamClient.Append]; append sessions send it once at connect,
+	// see [AppendSessionOptions.StreamConfig].
+	StreamConfig *StreamConfig `json:"-"`
 }
 
 // Success response to an `append` request.
@@ -609,6 +615,11 @@ type AppendSessionOptions struct {
 	// Retry configuration for handling transient failures.
 	// Applies to management operations (basins, streams, tokens) and stream operations (read, append).
 	RetryConfig *RetryConfig
+	// Stream configuration to apply if the stream is created on append.
+	// Unset fields inherit the basin's default stream configuration.
+	// Ignored if the stream already exists.
+	// Sent when the session connects and reconnects.
+	StreamConfig *StreamConfig
 }
 
 type ListAccessTokensArgs struct {


### PR DESCRIPTION
Adds `StreamConfig *StreamConfig` to `AppendInput` (unary append), `ReadOptions` (read and read session), and `AppendSessionOptions` (sent on session connect and reconnect; producers inherit it from their session). Mirrors the Rust SDK's `AppendInput.stream_config`, `ReadInput.stream_config`, and `AppendSessionConfig::with_stream_config`. The client sends the config as the `s2-stream-config` header; the server applies it over the basin default stream config only if that request auto-creates the stream (basin `create_stream_on_append` / `create_stream_on_read`) and ignores it once the stream exists. Server side: s2-streamstore/s2#718, s2-streamstore/s2-cloud#1767.

```go
ack, err := stream.Append(ctx, &s2.AppendInput{
    Records: []s2.AppendRecord{{Body: []byte("hello")}},
    StreamConfig: &s2.StreamConfig{
        RetentionPolicy: &s2.RetentionPolicy{Age: s2.Int64(3600)},
    },
})
```